### PR TITLE
SD-1273 Change dependencies to SD versions

### DIFF
--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -21,7 +21,7 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/scalingdata/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
 	"io"

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -21,7 +21,7 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/scalingdata/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
 	"io"


### PR DESCRIPTION
Snappy is the only transitive dep, and we already have a clone.