### PR TITLE
Not compatible with apache avro's implement.And this byte is useless.

### DIFF
--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -21,13 +21,14 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
 	"io"
 	"log"
 	"math/rand"
 	"time"
+
+	"code.google.com/p/snappy-go/snappy"
 )
 
 // DefaultWriterBlockSizeo specifies the default number of datum items
@@ -418,9 +419,6 @@ func writer(fw *Writer, toWrite <-chan *writerBlock) {
 			// } else {
 			// 	log.Printf("[DEBUG] block written: %d, %d, %v", len(block.items), len(block.compressed), block.compressed)
 		}
-	}
-	if fw.err = longCodec.Encode(fw.w, int64(0)); fw.err == nil {
-		fw.err = longCodec.Encode(fw.w, int64(0))
 	}
 	fw.writerDone <- struct{}{}
 }


### PR DESCRIPTION
This empty byte crashed apache/avro's reader implement.

Crashed example is shown below,and remove the empty tail byte easily fixed it.

## apache/avro python client:

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from httplib import HTTPConnection
from StringIO import StringIO
import avro.schema as schema
import avro.io as io
from avro.datafile import DataFileReader

schema = schema.parse(open("goserver_schema.avsc").read())
server_addr = ('localhost', 8888)

if __name__ == '__main__':
    conn = HTTPConnection(server_addr[0], server_addr[1])
    conn.request("POST", "/")
    resp = conn.getresponse()

    data = resp.read()
    reader = DataFileReader(StringIO(data), io.DatumReader())

    for a in reader:
        print a
    reader.close()
```

## linkedin/goavro go server:

```go
package main

import (
	"log"
	"net/http"

	"github.com/wuranbo/goavro"
)

var codec goavro.Codec
var recordSchema string = `
{
	"type": "record",
	"name": "comments",
	"doc:": "A basic schema for storing blog comments",
	"namespace": "com.example",
	"fields": [
	{
		"doc": "Name of user",
		"type": "string",
		"name": "username"
	},
	{
		"doc": "The content of the user's message",
		"type": "string",
		"name": "comment"
	},
	{
		"doc": "Unix epoch time in milliseconds",
		"type": "long",
		"name": "timestamp"
	}
	]
}
`

type Hello struct{}

func (h Hello) ServeHTTP(
	w http.ResponseWriter,
	r *http.Request) {

	fw, err := codec.NewWriter(
		// goavro.Compression(goavro.CompressionSnappy),
		goavro.Compression(goavro.CompressionNull),
		goavro.WriterSchema(recordSchema),
		goavro.BufferToWriter(w))

	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		fw.Close()
	}()

	someRecord, err := goavro.NewRecord(goavro.RecordSchema(recordSchema))
	if err != nil {
		log.Fatal(err)
	}

	someRecord.Set("username", "goodman")
	someRecord.Set("comment", "goodman die loney.")
	someRecord.Set("timestamp", int64(1))
	fw.Write(someRecord)

	if someRecord, err = goavro.NewRecord(goavro.RecordSchema(recordSchema)); err != nil {
		log.Fatal(err)
	}
	someRecord.Set("username", "badman")
	someRecord.Set("comment", "badman is bad.")
	someRecord.Set("timestamp", int64(2))
	fw.Write(someRecord)

}

func main() {
	var h Hello
	err := http.ListenAndServe("localhost:8888", h)
	if err != nil {
		log.Fatal(err)
	}
}

func init() {
	var err error
	codec, err = goavro.NewCodec(recordSchema)
	if err != nil {
		log.Fatal(err)
	}

}
```