### PR TITLE
*fix) bugfix when union and nil appear.

### DIFF
--- a/record.go
+++ b/record.go
@@ -68,6 +68,9 @@ func (r Record) GetFieldSchema(fieldName string) (interface{}, error) {
 
 // Set updates the datum of the specified Record field.
 func (r Record) Set(fieldName string, value interface{}) error {
+	if value == nil {
+		value = NULL_RECORD
+	}
 	// qualify fieldName searches based on record namespace
 	fn, _ := newName(nameName(fieldName), nameNamespace(r.n.ns))
 


### PR DESCRIPTION
replace #11 with this.

bug1 fix: The nil is treaded not right.It is a wrong usage of golang nil typeof. codec.go:412 fixing.

bug2 fix: The not setting value which's in a uion containing "null" and it's default is not "null" working not right. Other code fixing.

And better interface when you want to reset a value to null, after fixing you can Record.Set(k, nil) directly, before fixing you do this will cause bug2.