### PR TITLE
Reader.Scan() is buggly.

### DIFF
--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -21,11 +21,12 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
 	"io"
 	"io/ioutil"
+
+	"code.google.com/p/snappy-go/snappy"
 )
 
 // ErrReaderInit is returned when the encoder encounters an error.
@@ -189,6 +190,16 @@ func NewReader(setters ...ReaderSetter) (*Reader, error) {
 // Close releases resources and returns any Reader errors.
 func (fr *Reader) Close() error {
 	return fr.err
+}
+
+// Use this to Scan.Scan() is buggly, cause done and deblocked the two avr, will not atomic ever.
+func (fr *Reader) ScanData(doing func(interface{}, error) error) {
+	for fr.datum = range fr.deblocked {
+		err := doing(fr.Read())
+		if err != nil {
+			break
+		}
+	}
 }
 
 // Scan returns true if more data is ready to be read.


### PR DESCRIPTION
The concurrency bug I met for example:
When only has one block to read.The Reader.decode() run one time and set fr.done=true.If unfortunately the decode() routine make this change in the two line of Reader.Scan(), so  Scan() return !fr.done == false.No data will scan in this case.