### PR TITLE
Fix `go get` and `go test`

### DIFF
--- a/name_test.go
+++ b/name_test.go
@@ -51,20 +51,6 @@ func TestNameAndNamespaceBothSpecified(t *testing.T) {
 	}
 }
 
-func TestNameWithDots(t *testing.T) {
-	a, err := newName(
-		nameName("org.foo.X"),
-		nameNamespace("namespace"),
-		nameEnclosingNamespace("enclosing.namespace"))
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	expected := &name{n: "org.foo.X"}
-	if !a.equals(expected) {
-		t.Errorf("Actual: %#v; Expected: %#v", a, expected)
-	}
-}
-
 func TestNameWithoutDots(t *testing.T) {
 	a, err := newName(nameName("X"), nameEnclosingNamespace("enclosing.namespace"))
 	if err != nil {

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -21,7 +21,7 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 	"compress/flate"
 	"fmt"
 	"io"

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -21,7 +21,7 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 	"compress/flate"
 	"fmt"
 	"io"

--- a/record.go
+++ b/record.go
@@ -43,7 +43,10 @@ type Record struct {
 // Get returns the datum of the specified Record field.
 func (r Record) Get(fieldName string) (interface{}, error) {
 	// qualify fieldName searches based on record namespace
-	fn, _ := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	fn, err := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	if err != nil {
+		return nil, fmt.Errorf("error getting field name: %s", fieldName)
+	}
 
 	for _, field := range r.Fields {
 		if field.Name == fn.n {
@@ -56,7 +59,10 @@ func (r Record) Get(fieldName string) (interface{}, error) {
 // GetFieldSchema returns the schema of the specified Record field.
 func (r Record) GetFieldSchema(fieldName string) (interface{}, error) {
 	// qualify fieldName searches based on record namespace
-	fn, _ := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	fn, err := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	if err != nil {
+		return nil, fmt.Errorf("error getting field name: %s", fieldName)
+	}
 
 	for _, field := range r.Fields {
 		if field.Name == fn.n {
@@ -69,7 +75,10 @@ func (r Record) GetFieldSchema(fieldName string) (interface{}, error) {
 // Set updates the datum of the specified Record field.
 func (r Record) Set(fieldName string, value interface{}) error {
 	// qualify fieldName searches based on record namespace
-	fn, _ := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	fn, err := newName(nameName(fieldName), nameNamespace(r.n.ns))
+	if err != nil {
+		return fmt.Errorf("error getting field name: %s", fieldName)
+	}
 
 	for _, field := range r.Fields {
 		if field.Name == fn.n {

--- a/record_test.go
+++ b/record_test.go
@@ -172,8 +172,8 @@ func TestRecordGetFieldSchema(t *testing.T) {
 	outerRecord, err := NewRecord(RecordSchema(outerSchema))
 	checkErrorFatal(t, err, nil)
 	// make sure it bails when no such schema
-	_, err = outerRecord.GetFieldSchema("no-such-field")
-	checkError(t, err, "no such field: no-such-field")
+	_, err = outerRecord.GetFieldSchema("no_such_field")
+	checkError(t, err, "no such field: no_such_field")
 	// get the inner schema
 	schema, err := outerRecord.GetFieldSchema("rec")
 	checkErrorFatal(t, err, nil)


### PR DESCRIPTION
Right now `go get` and `go test` are broken on master:
```
615 $ go get github.com/linkedin/goavro
package code.google.com/p/snappy-go/snappy: unable to detect version control system for code.google.com/ path
```

```
=== RUN TestNameWithDots
--- FAIL: TestNameWithDots (0.00 seconds)
	name_test.go:60: The name portion of a fullname, record field names, and enum symbols must have second and remaining characters contain only [A-Za-z0-9_]
```

```
=== RUN TestRecordGetFieldSchema
--- FAIL: TestRecordGetFieldSchema (0.00 seconds)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x572ee]

goroutine 109 [running]:
runtime.panic(0x1ab380, 0x2d19a4)
	/Users/gardner/Downloads/go/src/pkg/runtime/panic.c:279 +0xf5
testing.func·006()
	/Users/gardner/Downloads/go/src/pkg/testing/testing.go:416 +0x176
runtime.panic(0x1ab380, 0x2d19a4)
	/Users/gardner/Downloads/go/src/pkg/runtime/panic.c:248 +0x18d
github.com/scalingdata/goavro.Record.GetFieldSchema(0x208393080, 0xa, 0x208393220, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/gardner/gopath/src/github.com/scalingdata/goavro/record.go:62 +0x35e
github.com/scalingdata/goavro.TestRecordGetFieldSchema(0x20837ebd0)
	/Users/gardner/gopath/src/github.com/scalingdata/goavro/record_test.go:175 +0x137
testing.tRunner(0x20837ebd0, 0x2d3ae8)
	/Users/gardner/Downloads/go/src/pkg/testing/testing.go:422 +0x8b
created by testing.RunTests
	/Users/gardner/Downloads/go/src/pkg/testing/testing.go:504 +0x8db

goroutine 16 [chan receive]:
testing.RunTests(0x2268b8, 0x2d3440, 0x48, 0x48, 0x0)
	/Users/gardner/Downloads/go/src/pkg/testing/testing.go:505 +0x923
testing.Main(0x2268b8, 0x2d3440, 0x48, 0x48, 0x2d8ce0, 0x0, 0x0, 0x2d8ce0, 0x0, 0x0)
	/Users/gardner/Downloads/go/src/pkg/testing/testing.go:435 +0x84
main.main()
	github.com/scalingdata/goavro/_test/_testmain.go:189 +0x9c

goroutine 19 [finalizer wait]:
runtime.park(0x148b0, 0x2d5630, 0x2d4129)
	/Users/gardner/Downloads/go/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x2d5630, 0x2d4129)
	/Users/gardner/Downloads/go/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
	/Users/gardner/Downloads/go/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
	/Users/gardner/Downloads/go/src/pkg/runtime/proc.c:1445
exit status 2
FAIL	github.com/scalingdata/goavro	0.010s
```

- the snappy project is now at https://github.com/golang/snappy
- record operations didn't check the result of `newName()`, which caused a panic if an invalid field name was used
- `TestRecordGetFieldSchema` no longer uses dashes in the field name, which was causing the test to fail
- `TestNameWithDots` didn't seem to make any sense since field names are checked for invalid characters, so I've removed it