### PR TITLE
update snappy library import path

### DIFF
--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -21,9 +21,9 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
+	"github.com/golang/snappy"
 	"io"
 	"io/ioutil"
 )

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -21,9 +21,9 @@ package goavro
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
 	"compress/flate"
 	"fmt"
+	"github.com/golang/snappy"
 	"io"
 	"log"
 	"math/rand"
@@ -387,10 +387,7 @@ func compressor(fw *Writer, toCompress <-chan *writerBlock, toWrite chan<- *writ
 		}
 	case CompressionSnappy:
 		for block := range toCompress {
-			block.compressed, block.err = snappy.Encode(block.compressed, block.encoded.Bytes())
-			if block.err != nil {
-				block.err = fmt.Errorf("cannot compress: %v", block.err)
-			}
+			block.compressed = snappy.Encode(block.compressed, block.encoded.Bytes())
 			toWrite <- block
 		}
 	}


### PR DESCRIPTION
Hi,

The snappy library had been moved from

code.google.com/p/snappy-go/snappy

to

github.com/golang/snappy/snappy

I have updated it to fix the "cannot find package" error when running the command "go get".
