### PR TITLE
Using go-fuzz to find and then fix several bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ is a layer of abstraction that also sits above Avro Data Serialization
 format, but has its own schema. Like Avro Object Container Files, this
 has been implemented but removed until the API can be improved.
 
+### Default maximum length of `String` and `Bytes` fields
+
+Because the way we currently decode String and Bytes fields is entirely
+stateless an Avro file could specify that a String or Bytes field is
+extremely large and there would be no way for the decode function to know
+anything was wrong. Instead of checking the available system memory on
+every decode operation, we've instead decided to opt for what we believe
+to be a sane default (`math.MaxInt32` or ~2.2GB) but leave that variable exported so that a user
+can change the variable if they need to exceed this limit.
+
 ## License
 
 ### Goavro license

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -41,7 +41,35 @@ func testFuzz(crasher string) error {
 
 // This is where we put anything that just caused a panic and wasn't solved by returning an error
 func TestFuzz_Panics(t *testing.T) {
-	var crashers = []string{}
+	var crashers = []string{
+		"Obj\x01\x04\x14avro.codec\fsna" +
+			"ppy\x16avro.schema\xf2\x05{\"t" +
+			"ype\":\"record\",\"name\"" +
+			":\"twitter_schema\",\"n" +
+			"amespace\":\"com.migun" +
+			"o.avro\",\"fields\":[{\"" +
+			"name\":\"username\",\"ty" +
+			"pe\":\"string\",\"doc\":\"" +
+			"Name of the user acc" +
+			"ount on Twitter.com\"" +
+			"},{\"name\":\"tweet\",\"t" +
+			"ype\":\"string\",\"doc\":" +
+			"\"The content of the " +
+			"user's Twitter messa" +
+			"ge\"},{\"name\":\"timest" +
+			"amp\",\"type\":\"null\",\"" +
+			"doc\":\"Unix epoch tim" +
+			"e in milliseconds\"}]" +
+			",\"doc:\":\"A basic sch" +
+			"ema for storing Twit" +
+			"ter messages\"}\x005\\\x951\xa4" +
+			"\xae~\xa2\x8f\xdc\xf8\xa3H\x87\x83\x80\x04\xd6\x01d\xf0c\fmi" +
+			"gunoFRock: Nerf pape" +
+			"r, scissors is fine." +
+			"\xb2\xb8\xee\x96\n\x14BlizzardCSFWor" +
+			"ks as intended.  Ter" +
+			"ran is IMBA.\xe2\xf3\xee\x96\n",
+	}
 
 	for n, data := range crashers {
 		if err := testFuzz(data); err != nil {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,96 @@
+package goavro
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func testFuzz(crasher string) error {
+	fr, err := NewReader(FromReader(strings.NewReader(crasher)))
+	if err != nil {
+		return err
+	}
+
+	var datums []interface{}
+
+	for fr.Scan() {
+		datum, err := fr.Read()
+		if err != nil {
+			return err
+		}
+		datums = append(datums, datum)
+	}
+
+	codec, err := NewCodec(fr.DataSchema)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, datum := range datums {
+		bb := new(bytes.Buffer)
+		err := codec.Encode(bb, datum)
+		if err != nil {
+			panic(fmt.Sprintf("%+v :: %s", datum, err))
+		}
+	}
+
+	return nil
+}
+
+// This is where we put anything that just caused a panic and wasn't solved by returning an error
+func TestFuzz_Panics(t *testing.T) {
+	var crashers = []string{}
+
+	for n, data := range crashers {
+		if err := testFuzz(data); err != nil {
+			t.Errorf("Error returned during fuzzing crasher[%v]: %v\n", n, err)
+		}
+	}
+}
+
+func TestFuzz_UnboundedAllocation(t *testing.T) {
+	var crashers = []string{
+		"Obj\x01\x04\x14avro.codec\fsna" +
+			"ppy\x16avro.schema\xf2\x05{\"t" +
+			"ype\":\"record\",\"name\"" +
+			":\"twitter_schema\",\"t" +
+			"ype\":\"com.miguno.avr" +
+			"o\",\"fields\":[{\"name\"" +
+			":\"username\",\"type\":\"" +
+			"string\",\"doc\":\"Name " +
+			"of the user account " +
+			"on Twitter.com\"},{\"n" +
+			"ame\":\"tweet\",\"type\":" +
+			"\"string\",\"doc\":\"The " +
+			"content of the user'" +
+			"s Twitter message\"}," +
+			"{\"name\":\"timestamp\"," +
+			"\"type\":\"long\",\"doc\":" +
+			"\"Unix epoch time in " +
+			"milliseconds\"}],\"doc" +
+			":\":\"A basic schema f" +
+			"or storing Twitter m" +
+			"essages\"}\x0003\x951\xa4\xae~\xa2\x8f\xdc" +
+			"\xf8\xa3H\x87\x83\x80\x04\xd6\x01d\xf0c\fmigunoF" +
+			"Rock: Nerf paper, sc" +
+			"issors is fine.\xb2\xb8\xee\x96\n" +
+			"\x14BlizzardCSFseconds\"" +
+			"}]Works as intended." +
+			"  Terran is IM",
+		"Obj\x010\xa2\x8f\xdc\xf8\xa30",
+		"Obj\x010ƕ�\b",
+	}
+
+	for n, data := range crashers {
+		if err := testFuzz(data); err != nil {
+			if strings.Contains(err.Error(), "greater than the max currently set with MaxDecodeSize") {
+				// Then we're handling the error properly
+				continue
+			}
+
+			t.Errorf("Error returned during fuzzing crasher[%v]: %v\n", n, err)
+		}
+	}
+}

--- a/record.go
+++ b/record.go
@@ -263,6 +263,12 @@ func newRecordField(schema interface{}, setters ...recordFieldSetter) (*recordFi
 	}
 	rf.schema = schema
 
+	// Null can only ever be null
+	if typeName == "null" {
+		rf.defval = nil
+		rf.hasDefault = true
+	}
+
 	// fields optional to the avro spec
 
 	val, ok := schemaMap["default"]

--- a/record_test.go
+++ b/record_test.go
@@ -19,6 +19,7 @@
 package goavro
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -181,4 +182,19 @@ func TestRecordGetFieldSchema(t *testing.T) {
 	if !ok {
 		t.Errorf("Actual: %#v; Expected: %#v", ok, true)
 	}
+}
+
+func TestNullField(t *testing.T) {
+	someJSONSchema := `{"type":"record","name":"Foo","fields":[{"type":"null","name":"field1"}]}`
+
+	codec, err := NewCodec(someJSONSchema)
+	checkError(t, err, nil)
+
+	bb := bytes.NewBufferString("")
+
+	rec, err := NewRecord(RecordSchema(someJSONSchema))
+	checkError(t, err, nil)
+
+	err = codec.Encode(bb, rec)
+	checkError(t, err, nil)
 }


### PR DESCRIPTION
This PR fixes two issues
* __Fix undefined nil field__  
When attempting to encode a datum with a schema, if that schema had a
field not included in the datum and that field is a Null, there is no
reason to die. To fix this we just set the default value for all Null
fields to nil.
* __Fix unbounded allocation with a malformed Avro file__  
When the long that defines how long a String or Bytes field is
inaccurate or just really large bytesDecoder and stringDecoder have no
way of knowing if it is accurate or even reasonable. Set a sane max and
allow user's to change it if they need to