### PR TITLE
Fix encoding for longs

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -158,6 +158,12 @@ func TestCodecRoundTrip(t *testing.T) {
 	checkCodecRoundTrip(t, `"long"`, int64(2269530520879620))
 	checkCodecRoundTrip(t, `"long"`, int64(3))
 	checkCodecRoundTrip(t, `"long"`, int64(64))
+
+	checkCodecRoundTrip(t, `"long"`, int64(-(1 << 63)))
+	checkCodecRoundTrip(t, `"long"`, int64((1<<63)-1))
+	checkCodecRoundTrip(t, `"long"`, int64(5959107741628848600))
+	checkCodecRoundTrip(t, `"long"`, int64(1359702038045356208))
+
 	// float
 	checkCodecRoundTrip(t, `"float"`, float32(3.5))
 	// checkCodecRoundTrip(t, `"float"`, float32(math.Inf(-1)))

--- a/decoder.go
+++ b/decoder.go
@@ -120,14 +120,14 @@ func intDecoder(r io.Reader) (interface{}, error) {
 }
 
 func longDecoder(r io.Reader) (interface{}, error) {
-	var v int
+	var v uint64
 	buf := make([]byte, 1)
 	for shift := uint(0); ; shift += 7 {
 		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, newDecoderError("long", err)
 		}
 		b := buf[0]
-		v |= int(b&mask) << shift
+		v |= uint64(b&mask) << shift
 		if b&flag == 0 {
 			break
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -99,7 +99,7 @@ func booleanEncoder(w io.Writer, datum interface{}) error {
 	return nil
 }
 
-func writeInt(w io.Writer, byteCount int, encoded int64) error {
+func writeInt(w io.Writer, byteCount int, encoded uint64) error {
 	var err error
 	var bb []byte
 	bw, ok := w.(ByteWriter)
@@ -151,7 +151,7 @@ func intEncoder(w io.Writer, datum interface{}) error {
 	if !ok {
 		return newEncoderError("int", "expected: int32; received: %T", datum)
 	}
-	encoded := int64((someInt << 1) ^ (someInt >> downShift))
+	encoded := uint64((someInt << 1) ^ (someInt >> downShift))
 	const maxByteSize = 5
 	return writeInt(w, maxByteSize, encoded)
 }
@@ -162,7 +162,7 @@ func longEncoder(w io.Writer, datum interface{}) error {
 	if !ok {
 		return newEncoderError("long", "expected: int64; received: %T", datum)
 	}
-	encoded := int64((someInt << 1) ^ (someInt >> downShift))
+	encoded := uint64((someInt << 1) ^ (someInt >> downShift))
 	const maxByteSize = 10
 	return writeInt(w, maxByteSize, encoded)
 }


### PR DESCRIPTION
Longs could be encoded incorrectly and were often decoded incorrectly. Added a couple of tests and code that fixes the tests.

There were other tests failing prior to this pull request: TestCodecDecoderUnionErrorYieldsName, TestFuzz_Panics, TestNameWithDots, TestRecordGetFieldSchema. This pull request does not address prior broken tests.