### PR TITLE
Respect nullable record fields without explicit defaults

### DIFF
--- a/record.go
+++ b/record.go
@@ -305,6 +305,14 @@ func newRecordField(schema interface{}, setters ...recordFieldSetter) (*recordFi
 		rf.hasDefault = true
 	}
 
+	// Nullable fields ( {"type": ["null", "string"], ...} ) have a default of nil
+	if typeSlice, ok := typeName.([]interface{}); ok {
+		if typeSlice[0] == "null" {
+			rf.defval = nil
+			rf.hasDefault = true
+		}
+	}
+
 	// fields optional to the avro spec
 
 	val, ok := schemaMap["default"]


### PR DESCRIPTION
Fix for #33 

Based on the [comment](https://github.com/linkedin/goavro/pull/26#issuecomment-143338601) in #26, nil should be the default value if a field's union type is [ "null", x ] since null is the first element of the union.