### PR TITLE
fixed int encoding

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -151,9 +151,9 @@ func intEncoder(w io.Writer, datum interface{}) error {
 	if !ok {
 		return newEncoderError("int", "expected: int32; received: %T", datum)
 	}
-	encoded := uint64((someInt << 1) ^ (someInt >> downShift))
+	encoded := uint32((someInt << 1) ^ (someInt >> downShift))
 	const maxByteSize = 5
-	return writeInt(w, maxByteSize, encoded)
+	return writeInt(w, maxByteSize, uint64(encoded))
 }
 
 func longEncoder(w io.Writer, datum interface{}) error {


### PR DESCRIPTION
It's a minor change but I was getting invalid AVRO files when encoding some int32 integers that were large e.g. 1455301406. The code was encoding them over 10 bytes as if they were long i.e. the zig zag encoding is now done over 32 bits instead of 64 bits.