### PR TITLE
Fix 32-bit integer zig-zag encoding for large values

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -146,6 +146,8 @@ func TestCodecRoundTrip(t *testing.T) {
 	checkCodecRoundTrip(t, `"int"`, int32(64))
 	checkCodecRoundTrip(t, `"int"`, int32(66052))
 	checkCodecRoundTrip(t, `"int"`, int32(8454660))
+	checkCodecRoundTrip(t, `"int"`, int32(2147483647))
+	checkCodecRoundTrip(t, `"int"`, int32(-2147483647))
 	// long
 	checkCodecRoundTrip(t, `"long"`, int64(-2147483648))
 	checkCodecRoundTrip(t, `"long"`, int64(-3))
@@ -297,6 +299,8 @@ func TestCodecEncoderPrimitives(t *testing.T) {
 	checkCodecEncoderResult(t, `"int"`, int32(64), []byte("\x80\x01"))
 	checkCodecEncoderResult(t, `"int"`, int32(66052), []byte("\x88\x88\x08"))
 	checkCodecEncoderResult(t, `"int"`, int32(8454660), []byte("\x88\x88\x88\x08"))
+	checkCodecEncoderResult(t, `"int"`, int32(2147483647), []byte("\xfe\xff\xff\xff\x0f"))
+	checkCodecEncoderResult(t, `"int"`, int32(-2147483647), []byte("\xfd\xff\xff\xff\x0f"))
 	// long
 	checkCodecEncoderResult(t, `"long"`, int64(-2147483648), []byte("\xff\xff\xff\xff\x0f"))
 	checkCodecEncoderResult(t, `"long"`, int64(-3), []byte("\x05"))

--- a/encoder.go
+++ b/encoder.go
@@ -151,7 +151,7 @@ func intEncoder(w io.Writer, datum interface{}) error {
 	if !ok {
 		return newEncoderError("int", "expected: int32; received: %T", datum)
 	}
-	encoded := uint64((someInt << 1) ^ (someInt >> downShift))
+	encoded := uint64((uint32(someInt) << 1) ^ uint32(someInt>>downShift))
 	const maxByteSize = 5
 	return writeInt(w, maxByteSize, encoded)
 }


### PR DESCRIPTION
Bitwise shifts in Go are arithmetic for signed integer types. Cast the number to be shifted to `uint32` first to ensure we can encode the full range of 32-bit integers. Add some round-trip tests to verify.