### PR TITLE
Add fixed type

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -402,6 +402,8 @@ func (st symtab) makeUnionCodec(enclosingNamespace string, schema interface{}) (
 				name = "null"
 			case Enum:
 				name = datum.(Enum).Name
+			case Fixed:
+				name = datum.(Fixed).Name
 			case *Record:
 				name = datum.(*Record).Name
 			}
@@ -498,6 +500,17 @@ func (st symtab) makeEnumCodec(enclosingNamespace string, schema interface{}) (*
 	return c, nil
 }
 
+// Fixed is an abstract data type used to hold data corresponding to an Avro
+// 'Fixed' type. Whenever an Avro schema specifies a "Fixed" type, this library's
+// Decode method will return a Fixed value  initialized to the Fixed naem, and
+// value read from the io.Reader. Likewise, when using Encode to convert data to
+// an Avro record, it is necessary to create and send a Fixed instance to the
+// Encode method.
+type Fixed struct {
+	Name  string
+	Value []byte
+}
+
 func (st symtab) makeFixedCodec(enclosingNamespace string, schema interface{}) (*codec, error) {
 	errorNamespace := "null namespace"
 	if enclosingNamespace != nullNamespace {
@@ -535,17 +548,17 @@ func (st symtab) makeFixedCodec(enclosingNamespace string, schema interface{}) (
 			if n < int(size) {
 				return nil, newDecoderError(friendlyName, "buffer underrun")
 			}
-			return buf, nil
+			return Fixed{Name: nm.n, Value: buf}, nil
 		},
 		ef: func(w io.Writer, datum interface{}) error {
-			someBytes, ok := datum.([]byte)
+			someFixed, ok := datum.(Fixed)
 			if !ok {
-				return newEncoderError(friendlyName, "expected: []byte; received: %T", datum)
+				return newEncoderError(friendlyName, "expected: Fixed; received: %T", datum)
 			}
-			if len(someBytes) != int(size) {
-				return newEncoderError(friendlyName, "expected: %d bytes; received: %d", size, len(someBytes))
+			if len(someFixed.Value) != int(size) {
+				return newEncoderError(friendlyName, "expected: %d bytes; received: %d", size, len(someFixed.Value))
 			}
-			n, err := w.Write(someBytes)
+			n, err := w.Write(someFixed.Value)
 			if err != nil {
 				return newEncoderError(friendlyName, err)
 			}

--- a/codec.go
+++ b/codec.go
@@ -502,7 +502,7 @@ func (st symtab) makeEnumCodec(enclosingNamespace string, schema interface{}) (*
 
 // Fixed is an abstract data type used to hold data corresponding to an Avro
 // 'Fixed' type. Whenever an Avro schema specifies a "Fixed" type, this library's
-// Decode method will return a Fixed value  initialized to the Fixed naem, and
+// Decode method will return a Fixed value  initialized to the Fixed name, and
 // value read from the io.Reader. Likewise, when using Encode to convert data to
 // an Avro record, it is necessary to create and send a Fixed instance to the
 // Encode method.

--- a/codec_test.go
+++ b/codec_test.go
@@ -494,11 +494,16 @@ func TestCodecFixed(t *testing.T) {
 	checkCodecEncoderResult(t, schema, []byte("happy"), []byte("happy"))
 }
 
-func TestCodecNamedTypes(t *testing.T) {
+func TestCodecNamedTypesCheckSchema(t *testing.T) {
 	schema := `{"name":"guid","type":{"type":"fixed","name":"fixed_16","size":16},"doc":"event unique id"}`
 	var err error
 	_, err = NewCodec(schema)
 	checkError(t, err, nil)
+}
+
+func TestCodecNamedTypes(t *testing.T) {
+	schema := `{"name":"guid","type":["null",{"type":"fixed","name":"fixed_16","size":16}],"doc":"event unique id"}`
+	checkCodecEncoderResult(t, schema, Fixed{Name: "fixed_16", Value: []byte("0123456789abcdef")}, append([]byte{0x2}, []byte("0123456789abcdef")...))
 }
 
 func TestCodecReferToNamedTypes(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -488,10 +488,10 @@ func TestCodecFixed(t *testing.T) {
 	schema := `{"type":"fixed","name":"fixed1","size":5}`
 	checkCodecDecoderError(t, schema, []byte(""), "EOF")
 	checkCodecDecoderError(t, schema, []byte("hap"), "buffer underrun")
-	checkCodecEncoderError(t, schema, "happy day", "expected: []byte; received: string")
-	checkCodecEncoderError(t, schema, []byte("day"), "expected: 5 bytes; received: 3")
-	checkCodecEncoderError(t, schema, []byte("happy day"), "expected: 5 bytes; received: 9")
-	checkCodecEncoderResult(t, schema, []byte("happy"), []byte("happy"))
+	checkCodecEncoderError(t, schema, "happy day", "expected: Fixed; received: string")
+	checkCodecEncoderError(t, schema, Fixed{Name: "fixed1", Value: []byte("day")}, "expected: 5 bytes; received: 3")
+	checkCodecEncoderError(t, schema, Fixed{Name: "fixed1", Value: []byte("happy day")}, "expected: 5 bytes; received: 9")
+	checkCodecEncoderResult(t, schema, Fixed{Name: "fixed1", Value: []byte("happy")}, []byte("happy"))
 }
 
 func TestCodecNamedTypesCheckSchema(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -503,6 +503,8 @@ func TestCodecNamedTypesCheckSchema(t *testing.T) {
 
 func TestCodecNamedTypes(t *testing.T) {
 	schema := `{"name":"guid","type":["null",{"type":"fixed","name":"fixed_16","size":16}],"doc":"event unique id"}`
+	// The 0x2 byte is an avro encoded int(1), which refers to the index of the
+	// `fixed_16` type in the schema's union array.
 	checkCodecEncoderResult(t, schema, Fixed{Name: "fixed_16", Value: []byte("0123456789abcdef")}, append([]byte{0x2}, []byte("0123456789abcdef")...))
 }
 


### PR DESCRIPTION
Goavro was unable to encode a union that contained a fixed type.  A "union" refers to a field that has more than 1 possible type (in the below example, field "guid" could have type `null` or `fixed_16`).  A fixed type is a specifically sized byte array, and a given name.

{"name":"guid","type":["null",{"type":"fixed","name":"fixed_16","size":16}],"doc":"event unique id"}

This PR adds a "Fixed" struct type.  Before, goavro would use golang's []byte primitive to represent fixed types.  This works for decoding, but encoding requires that the []byte have a name.  The Fixed struct type binds the "name" to the []byte value.