### PR TITLE
Fix inconsistency when decoding an enum

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -491,7 +491,7 @@ func (st symtab) makeEnumCodec(enclosingNamespace string, schema interface{}) (*
 			if index < 0 || index >= int64(len(symtab)) {
 				return nil, newDecoderError(friendlyName, "index must be between 0 and %d", len(symtab)-1)
 			}
-			return symtab[index], nil
+			return Enum{nm.n, symtab[index].(string)}, nil
 		},
 		ef: func(w io.Writer, datum interface{}) error {
 			someEnum, ok := datum.(Enum)

--- a/codec_test.go
+++ b/codec_test.go
@@ -457,7 +457,7 @@ func TestCodecDecoderEnum(t *testing.T) {
 	schema := `{"type":"enum","name":"cards","symbols":["HEARTS","DIAMONDS","SPADES","CLUBS"]}`
 	checkCodecDecoderError(t, schema, []byte("\x01"), "index must be between 0 and 3")
 	checkCodecDecoderError(t, schema, []byte("\x08"), "index must be between 0 and 3")
-	checkCodecDecoderResult(t, schema, []byte("\x04"), "SPADES")
+	checkCodecDecoderResult(t, schema, []byte("\x04"), Enum{"cards", "SPADES"})
 }
 
 func TestCodecEncoderEnum(t *testing.T) {


### PR DESCRIPTION
- return an `Enum` struct when decoding Avro enum instead of a string in order to be symmetrical with encoding
- update unit tests accordingly

Related issue #59.