### PR TITLE
[FixAliasesRecording] Fix recording of aliases

### DIFF
--- a/record.go
+++ b/record.go
@@ -382,9 +382,17 @@ func newRecordField(schema interface{}, setters ...recordFieldSetter) (*recordFi
 	}
 
 	if val, ok = schemaMap["aliases"]; ok {
-		rf.aliases, ok = val.([]string)
+		aliases, ok := schemaMap["aliases"].([]interface{})
 		if !ok {
 			return nil, newCodecBuildError("record field", "record field aliases ought to be array of strings")
+		}
+
+		for _, alias := range aliases {
+			aliasStr, ok := alias.(string)
+			if !ok {
+				return nil, newCodecBuildError("record field", "record field aliases ought to be array of strings")
+			}
+			rf.aliases = append(rf.aliases, aliasStr)
 		}
 	}
 

--- a/record_test.go
+++ b/record_test.go
@@ -78,6 +78,7 @@ func TestRecordField(t *testing.T) {
 	schema["name"] = "someRecordField"
 	schema["type"] = "int"
 	schema["doc"] = "contans some integer"
+	schema["aliases"] = []interface{}{"alias1", "alias2"}
 	someRecordField, err := newRecordField(schema)
 	checkError(t, err, nil)
 	if someRecordField.Name != "someRecordField" {


### PR DESCRIPTION
Golang does not permit complex type assertions such as []interface{} to
[]string. Instead, one must iterate through the elements of the slice.