### PR TITLE
Support field default values 

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -319,7 +319,11 @@ func (st symtab) buildString(enclosingNamespace, typeName string, schema interfa
 		return &codec{
 			nm: c.nm,
 			df: func(r io.Reader) (interface{}, error) {
-				return c.df(r)
+				i, err := c.df(r)
+				if err != nil && def != nil {
+					return def, nil
+				}
+				return i, err
 			},
 			ef: func(w io.Writer, datum interface{}) error {
 				err := c.ef(w, datum)

--- a/codec_test.go
+++ b/codec_test.go
@@ -425,6 +425,19 @@ func TestCodecUnionPrimitives(t *testing.T) {
 	checkCodecEncoderResult(t, `["string","null"]`, nil, []byte("\x02"))
 }
 
+func TestCodecDecodeDefaults(t *testing.T) {
+	checkCodecEncoderResult(t, `{"default": true, "name": "testField", "type":"boolean"}`, nil, []byte("\x01"))
+	checkCodecEncoderResult(t, `{"default": 1016, "name": "testField", "type":"int"}`, nil, []byte("\xf0\x0f"))
+	checkCodecEncoderResult(t, `{"default": 9007199254740992, "name": "testField", "type":"long"}`, nil, []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x20})
+	checkCodecEncoderResult(t, `{"default": 3.14159265359, "name": "testField", "type":"float"}`, nil, []byte{0xdb, 0xf, 0x49, 0x40})
+	checkCodecEncoderResult(t, `{"default": 3.14159265359, "name": "testField", "type":"double"}`, nil, []byte{0xea, 0x2e, 0x44, 0x54, 0xfb, 0x21, 0x9, 0x40})
+	checkCodecEncoderResult(t, `{"default": "RickAstley", "name": "testField", "type":"string"}`, nil, []byte{0x14, 0x52, 0x69, 0x63, 0x6b, 0x41, 0x73, 0x74, 0x6c, 0x65, 0x79})
+
+	checkCodecEncoderResult(t, `{"default":"blue","name":"color_enum","type":"enum","symbols":["red","blue","green"]}`, nil, []byte("\x02"))
+	// Type is map
+	checkCodecEncoderResult(t, `{"default": "blue","name":"color","type":{"name":"color_enum","type":"enum","symbols":["red","blue"]}}`, nil, []byte("\x02"))
+}
+
 func TestCodecDecoderUnion(t *testing.T) {
 	checkCodecDecoderResult(t, `["string","float"]`, []byte("\x00\x14filibuster"), "filibuster")
 	checkCodecDecoderResult(t, `["string","int"]`, []byte("\x02\x1a"), int32(13))

--- a/codec_test.go
+++ b/codec_test.go
@@ -425,7 +425,7 @@ func TestCodecUnionPrimitives(t *testing.T) {
 	checkCodecEncoderResult(t, `["string","null"]`, nil, []byte("\x02"))
 }
 
-func TestCodecDecodeDefaults(t *testing.T) {
+func TestCodecEncodeDefaults(t *testing.T) {
 	checkCodecEncoderResult(t, `{"default": true, "name": "testField", "type":"boolean"}`, nil, []byte("\x01"))
 	checkCodecEncoderResult(t, `{"default": 1016, "name": "testField", "type":"int"}`, nil, []byte("\xf0\x0f"))
 	checkCodecEncoderResult(t, `{"default": 9007199254740992, "name": "testField", "type":"long"}`, nil, []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x20})
@@ -436,6 +436,18 @@ func TestCodecDecodeDefaults(t *testing.T) {
 	checkCodecEncoderResult(t, `{"default":"blue","name":"color_enum","type":"enum","symbols":["red","blue","green"]}`, nil, []byte("\x02"))
 	// Type is map
 	checkCodecEncoderResult(t, `{"default": "blue","name":"color","type":{"name":"color_enum","type":"enum","symbols":["red","blue"]}}`, nil, []byte("\x02"))
+}
+
+func TestCodecDecodeDefaults(t *testing.T) {
+	checkCodecDecoderResult(t, `{"default": true, "name": "testField", "type":"boolean"}`, []byte{}, true)
+	checkCodecDecoderResult(t, `{"default": 1016, "name": "testField", "type":"int"}`, []byte{}, int32(1016))
+	checkCodecDecoderResult(t, `{"default": 9007199254740992, "name": "testField", "type":"long"}`, []byte{}, int64(9007199254740992))
+	checkCodecDecoderResult(t, `{"default": 3.14159265359, "name": "testField", "type":"float"}`, []byte{}, float32(3.14159265359))
+	checkCodecDecoderResult(t, `{"default": 3.14159265359, "name": "testField", "type":"double"}`, []byte{}, float64(3.14159265359))
+	checkCodecDecoderResult(t, `{"default": "RickAstley", "name": "testField", "type":"string"}`, []byte{}, "RickAstley")
+	checkCodecDecoderResult(t, `{"default":"blue","name":"color_enum","type":"enum","symbols":["red","blue","green"]}`, []byte{}, "blue")
+	// Type is map
+	checkCodecDecoderResult(t, `{"default": "blue","name":"color","type":{"name":"color_enum","type":"enum","symbols":["red","blue"]}}`, []byte{}, "blue")
 }
 
 func TestCodecDecoderUnion(t *testing.T) {


### PR DESCRIPTION
If a schema field provides a default value, and a record is encoded which doesn't include that field, the default value is used.  When a byte stream is decoded into a record, if there is no data for a given field, but the field has a default, the decoded record will contain the default value.

The motivation for these changes was to provide backwards compatibility.  A new schema, with added "default" fields should be able to decode records encoded with an older schema which doesn't contain those fields.  As an added benefit, fields which have default values do not need to be included when encoding a record.

This implementation is not complete.   

1.  Currently supports booleans, ints, longs, floats, doubles, strings, and enums.  It's missing support for default arrays, maps, fixed, records, and bytes.  
2.  Missing boundary checking around numerics. Because Go's json decoder unmarshals all numerics to float64, it'll be difficult to support default values outside that range.

Once I get a code-review on my current implementation, I can work on the above 2 things.