### PR TITLE
Name codec closures to systematically fix race conditions around shadowed variables

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -799,7 +799,7 @@ func (st symtab) makeArrayCodec(enclosingNamespace string, schema interface{}) (
 					}
 					data = append(data, datum)
 				}
-				someValue, err = longDecoder(r)
+				someValue, err := longDecoder(r)
 				if err != nil {
 					return nil, newDecoderError(friendlyName, err)
 				}
@@ -818,7 +818,7 @@ func (st symtab) makeArrayCodec(enclosingNamespace string, schema interface{}) (
 					rightIndex = len(someArray)
 				}
 				items := someArray[leftIndex:rightIndex]
-				err = longEncoder(w, int64(len(items)))
+				err := longEncoder(w, int64(len(items)))
 				if err != nil {
 					return newEncoderError(friendlyName, err)
 				}

--- a/codec.go
+++ b/codec.go
@@ -642,7 +642,7 @@ func (st symtab) makeRecordCodec(enclosingNamespace string, schema interface{}) 
 				return newEncoderError(friendlyName, "expected: %v; received: %v", recordTemplate.Name, someRecord.Name)
 			}
 			for idx, field := range someRecord.Fields {
-				err = fieldCodecs[idx].Encode(w, field.Datum)
+				err := fieldCodecs[idx].Encode(w, field.Datum)
 				if err != nil {
 					return newEncoderError(friendlyName, err)
 				}

--- a/race_test.go
+++ b/race_test.go
@@ -7,6 +7,57 @@ import (
 	"testing"
 )
 
+func TestRaceEncodeEncodeArray(t *testing.T) {
+	recordSchemaJSON := `{"type":"record","name":"record1","fields":[{"type":"array", "items":"long","name":"field1"}]}`
+	codec, _ := NewCodec(recordSchemaJSON)
+	done := make(chan error, 10)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			rec, err := NewRecord(RecordSchema(recordSchemaJSON))
+			if err != nil {
+				done <- err
+				return
+			}
+
+			rec.Set("field1", []interface{}{int64(i)})
+
+			bb := new(bytes.Buffer)
+			if err := codec.Encode(bb, rec); err != nil {
+				done <- err
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			rec, err := NewRecord(RecordSchema(recordSchemaJSON))
+			if err != nil {
+				done <- err
+				return
+			}
+
+			rec.Set("field1", []interface{}{int64(i)})
+			bb := new(bytes.Buffer)
+			if err := codec.Encode(bb, rec); err != nil {
+				done <- err
+				return
+			}
+		}
+
+	}()
+
+	wg.Wait()
+	close(done)
+	for err := range done {
+		t.Errorf("%v", err)
+	}
+}
 func TestRaceEncodeEncodeRecord(t *testing.T) {
 	recordSchemaJSON := `{"type":"record","name":"record1","fields":[{"type":"long","name":"field1"}]}`
 	codec, _ := NewCodec(recordSchemaJSON)


### PR DESCRIPTION
We found 2 more race conditions (in the record and array codecs) around error shadowing in the codec encode/decode closures.

To systematically fix them and to prevent them from regressing we got rid of the anonymous closures and replaced them with named ones.