### PR TITLE
Fixes #93

### DIFF
--- a/record.go
+++ b/record.go
@@ -63,6 +63,11 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 		if defaultValue, ok := fieldSchemaMap["default"]; ok {
 			// if codec is union, then default value ought to encode using first schema in union
 			if fieldCodec.typeName.short() == "union" {
+				// NOTE: To support a null default value,
+				// the string literal "null" must be coerced to a `nil`
+				if defaultValue == "null" {
+					defaultValue = nil
+				}
 				// NOTE: To support record field default values, union schema
 				// set to the type name of first member
 				defaultValue = Union(fieldCodec.schema, defaultValue)

--- a/schema_test.go
+++ b/schema_test.go
@@ -195,3 +195,41 @@ func TestMapValueTypeRecord(t *testing.T) {
 	// are returned as a Go map
 	testBinaryEncodePass(t, schema, datum, expected)
 }
+
+func TestDefaultValueOughtToEncodeUsingFieldSchemaOK(t *testing.T) {
+
+	testSchemaValid(t, `
+	{
+	  "namespace": "universe.of.things",
+	  "type": "record",
+	  "name": "Thing",
+	  "fields": [
+		{
+		  "name": "attributes",
+		  "type": [
+			"null",
+			{
+			  "type": "array",
+			  "items": {
+				"namespace": "universe.of.things",
+				"type": "record",
+				"name": "attribute",
+				"fields": [
+				  {
+					"name": "name",
+					"type": "string"
+				  },
+				  {
+					"name": "value",
+					"type": "string"
+				  }
+				]
+			  }
+			}
+		  ],
+		  "default": "null"
+		}
+	  ]
+	}`)
+
+}


### PR DESCRIPTION
The simplest fix appears to be a minor change to `makeRecordCodec` coercing the "null" to a `nil`so that the `Union` can properly process the datum.
