### PR TITLE
Only validate name, not all components

### DIFF
--- a/name.go
+++ b/name.go
@@ -75,6 +75,11 @@ func newName(n, ns, ens string) (*name, error) {
 		nn.namespace = n[:index]
 	} else {
 		// inputName does not contain a dot, therefore is not the full name
+		err := checkNameComponent(n)
+		if err != nil {
+			return nil, err
+		}
+
 		if ns != nullNamespace {
 			// if namespace provided in the schema in the same schema level, use it
 			nn.fullName = ns + "." + n
@@ -86,13 +91,6 @@ func newName(n, ns, ens string) (*name, error) {
 		} else {
 			// otherwise no namespace, so use null namespace, the empty string
 			nn.fullName = n
-		}
-	}
-
-	// verify all components of the full name for adherence to Avro naming rules
-	for _, component := range strings.Split(nn.fullName, ".") {
-		if err := checkNameComponent(component); err != nil {
-			return nil, err
 		}
 	}
 

--- a/name_test.go
+++ b/name_test.go
@@ -23,9 +23,22 @@ func TestNameStartsInvalidCharacter(t *testing.T) {
 }
 
 func TestNameContainsInvalidCharacter(t *testing.T) {
-	_, err := newName("X", "org.foo&bar", nullNamespace)
+	_, err := newName("X&", "org.foo.bar", nullNamespace)
 	if _, ok := err.(ErrInvalidName); err == nil && !ok {
 		t.Errorf("Actual: %#v, Expected: %#v", err, ErrInvalidName{"start with [A-Za-z_]"})
+	}
+}
+
+func TestNamespaceContainsInvalidCharacter(t *testing.T) {
+	n, err := newName("X", ".org.foo", nullNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual, expected := n.fullName, ".org.foo.X"; actual != expected {
+		t.Errorf("Actual: %#v; Expected: %#v", actual, expected)
+	}
+	if actual, expected := n.namespace, ".org.foo"; actual != expected {
+		t.Errorf("Actual: %#v; Expected: %#v", actual, expected)
 	}
 }
 


### PR DESCRIPTION
Despite the spec stating that each component is a name, the reference Java implementation only validates the actual name field. Match the [Java implementation](https://github.com/apache/avro/blob/branch-1.7/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L467) to be more compatible with OCF files written by other languages.

Specifically this has bitten us with a `namespace` field written by Spark that starts with a leading dot.