### PR TITLE
Add parsing canonical form to the Avro codec.

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -1,0 +1,140 @@
+package goavro
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// pcfProcessor is a function type that given a parsed JSON object, returns its
+// Parsing Canonical Form accroding to Avro specification
+type pcfProcessor func(s interface{}) string
+
+// parsingCanonialForm returns the "Parsing Canonical Form" (pcf) for a parsed
+// json structure of a valid Avro schema
+func parsingCanonicalForm(schema interface{}) string {
+	var proc pcfProcessor
+
+	proc = func(s interface{}) string {
+		switch val := s.(type) {
+		case map[string]interface{}: // A JSON map
+			return pcfMap(val, proc)
+		case []interface{}: //JSON array
+			return pcfArray(val, proc)
+		case string: // Standalone string
+			return pcfString(val, proc)
+		case float64:
+			return pcfFloat64(val, proc)
+		default:
+			// Invalid json element within the schema; ignore
+			return ""
+		}
+	}
+
+	return proc(schema)
+}
+
+// pcfFloat64 returns the parsing canonical form for a float64 value
+func pcfFloat64(val float64, proc pcfProcessor) string {
+	return fmt.Sprintf("%v", val)
+}
+
+// pcfString returns the parsing canonical form for a string value
+func pcfString(val string, proc pcfProcessor) string {
+	return "\"" + val + "\""
+}
+
+// pcfArray returns the parsing canonical form for a JSON array
+func pcfArray(val []interface{}, proc pcfProcessor) string {
+	var elements = make([]string, 0, len(val))
+	for _, el := range val {
+		elements = append(elements, proc(el))
+	}
+	return "[" + strings.Join(elements, ",") + "]"
+}
+
+// pcfMap returns the parsing canonical form for a JSON map
+func pcfMap(jsonMap map[string]interface{}, proc pcfProcessor) string {
+	var els = make(stringPairs, 0, len(jsonMap))
+
+	namespace := ""
+	//Remember the namespace to fully qualify names later
+	if namespaceJSON, ok := jsonMap["namespace"]; ok {
+		if namespaceStr, ok := namespaceJSON.(string); ok { // and it's value is string (otherwise invalid schema)
+			namespace = namespaceStr
+		}
+	}
+
+	for k, v := range jsonMap {
+
+		// Reduce primitive schemas to their simple form
+		if len(jsonMap) == 1 && k == "type" {
+			if t, ok := v.(string); ok {
+				return "\"" + t + "\""
+			}
+		}
+
+		// Only keep relevant attributes (strip 'doc', 'alias' or 'namespace')
+		if _, ok := fieldOrder[k]; !ok {
+			continue
+		}
+
+		// Add namespace to a non-qualified name
+		if k == "name" && namespace != "" {
+			// Check if the name isn't already qualified
+			if t, ok := v.(string); ok && !strings.Contains(t, ".") {
+				v = namespace + "." + t
+			}
+		}
+
+		els = append(els, stringPair{k, proc(k) + ":" + proc(v)})
+	}
+
+	// Sort keys by their order in spec
+	sort.Sort(byAvroFieldOrder(els))
+	return "{" + strings.Join(els.Bs(), ",") + "}"
+}
+
+// stringPair represents a pair of string values
+type stringPair struct {
+	A string
+	B string
+}
+
+// stringPairs is a sortable array of pair of strings
+type stringPairs []stringPair
+
+// Bs returns an array of second values of an array of pairs
+func (sp *stringPairs) Bs() []string {
+	out := make([]string, 0, len(*sp))
+	for _, el := range *sp {
+		out = append(out, el.B)
+	}
+	return out
+}
+
+// fieldOrder defines fields that show up in canonical schema and specifices their precedence
+var fieldOrder = map[string]int{
+	"name":    1,
+	"type":    2,
+	"fields":  3,
+	"symbols": 4,
+	"items":   5,
+	"values":  6,
+	"size":    7,
+}
+
+// byAvroFieldOrder is equipped with a sort order of fields according to the specs
+type byAvroFieldOrder []stringPair
+
+func (s byAvroFieldOrder) Len() int {
+	return len(s)
+}
+
+func (s byAvroFieldOrder) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byAvroFieldOrder) Less(i, j int) bool {
+	return fieldOrder[s[i].A] < fieldOrder[s[j].A]
+}

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -1,0 +1,184 @@
+package goavro_test
+
+import (
+	"testing"
+
+	"github.com/karrick/goavro"
+)
+
+func TestCanonicalSchema(t *testing.T) {
+
+	// Test cases are taken from the reference implementation here:
+	// https://github.com/apache/avro/blob/master/share/test/data/schema-tests.txt
+
+	cases := []struct {
+		Schema    string
+		Canonical string
+	}{
+		{
+			Schema:    `"null"`,
+			Canonical: `"null"`,
+		},
+		{
+			Schema:    `{"type":"null"}`,
+			Canonical: `"null"`,
+		},
+		{
+			Schema:    `"boolean"`,
+			Canonical: `"boolean"`,
+		},
+		{
+			Schema:    `{"type":"boolean"}`,
+			Canonical: `"boolean"`,
+		},
+		{
+			Schema:    `"int"`,
+			Canonical: `"int"`,
+		},
+		{
+			Schema:    `{"type":"int"}`,
+			Canonical: `"int"`,
+		},
+		{
+			Schema:    `"long"`,
+			Canonical: `"long"`,
+		},
+		{
+			Schema:    `{"type":"long"}`,
+			Canonical: `"long"`,
+		},
+		{
+			Schema:    `"float"`,
+			Canonical: `"float"`,
+		},
+		{
+			Schema:    `{"type":"float"}`,
+			Canonical: `"float"`,
+		},
+		{
+			Schema:    `"double"`,
+			Canonical: `"double"`,
+		},
+		{
+			Schema:    `{"type":"double"}`,
+			Canonical: `"double"`,
+		},
+		{
+			Schema:    `"bytes"`,
+			Canonical: `"bytes"`,
+		},
+		{
+			Schema:    `{"type":"bytes"}`,
+			Canonical: `"bytes"`,
+		},
+		{
+			Schema:    `"string"`,
+			Canonical: `"string"`,
+		},
+		{
+			Schema:    `{"type":"string"}`,
+			Canonical: `"string"`,
+		},
+		/*
+			// Supported by the reference implementation but not by goavro at this point
+			{
+				Schema:    "[  ]",
+				Canonical: "[]",
+			},
+		*/
+		{
+			Schema:    `[ "int"  ]`,
+			Canonical: `["int"]`,
+		},
+		{
+			Schema:    `[ "int" , {"type":"boolean"} ]`,
+			Canonical: `["int","boolean"]`,
+		},
+
+		// The following 7 test cases differ from the reference implementation since goavro doesn't
+		// currently support empty fields array. A field name "dummy" is added since these tests are
+		// testing other aspects of canonicalization than empty field array.
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo"}`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo", "namespace":"x.y"}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo", "namespace":"x.y"}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"a.b.foo", "namespace":"x.y"}`,
+			Canonical: `{"name":"a.b.foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo", "doc":"Useful info"}`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo", "aliases":["foo","bar"]}`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"fields":[{"name":"dummy","type":"int"}], "type":"record", "name":"foo", "doc":"foo", "aliases":["foo","bar"]}`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"dummy","type":"int"}]}`,
+		},
+
+		{
+			Schema:    `{"fields":[{"type":{"type":"boolean"}, "name":"f1"}], "type":"record", "name":"foo"}`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean"}]}`,
+		},
+		{
+			Schema: `{ "fields":[{"type":"boolean", "aliases":[], "name":"f1", "default":true},
+			            {"order":"descending","name":"f2","doc":"Hello","type":"int"}],
+						  "type":"record", "name":"foo"
+						  }`,
+			Canonical: `{"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean"},{"name":"f2","type":"int"}]}`,
+		},
+		{
+			Schema:    `{"type":"enum", "name":"foo", "symbols":["A1"]}`,
+			Canonical: `{"name":"foo","type":"enum","symbols":["A1"]}`,
+		},
+		{
+			Schema:    `{"namespace":"x.y.z", "type":"enum", "name":"foo", "doc":"foo bar", "symbols":["A1", "A2"]}`,
+			Canonical: `{"name":"x.y.z.foo","type":"enum","symbols":["A1","A2"]}`,
+		},
+		{
+			Schema:    `{"name":"foo","type":"fixed","size":15}`,
+			Canonical: `{"name":"foo","type":"fixed","size":15}`,
+		},
+		{
+			Schema:    `{"namespace":"x.y.z", "type":"fixed", "name":"foo", "doc":"foo bar", "size":32}`,
+			Canonical: `{"name":"x.y.z.foo","type":"fixed","size":32}`,
+		},
+		{
+			Schema:    `{ "items":{"type":"null"}, "type":"array"}`,
+			Canonical: `{"type":"array","items":"null"}`,
+		},
+		{
+			Schema:    `{ "values":"string", "type":"map"}`,
+			Canonical: `{"type":"map","values":"string"}`,
+		},
+		{
+			Schema: `  {"name":"PigValue","type":"record",
+			   "fields":[{"name":"value", "type":["null", "int", "long", "PigValue"]}]}`,
+			Canonical: `{"name":"PigValue","type":"record","fields":[{"name":"value","type":["null","int","long","PigValue"]}]}`,
+		},
+	}
+
+	for _, c := range cases {
+
+		codec, err := goavro.NewCodec(c.Schema)
+		if err != nil {
+			t.Errorf("Unable to create codec for schema: %s\n  with error: %s", c.Schema, err)
+		}
+
+		want := c.Canonical
+		if got := codec.CanonicalSchema(); got != want {
+			t.Errorf("Test failed for schema: %s \n  expected canonical: %s \n  got canonical: %s", c.Schema, want, got)
+		}
+	}
+}

--- a/codec.go
+++ b/codec.go
@@ -44,8 +44,9 @@ var (
 // Codec is created as a stateless structure that can be safely used in multiple
 // go routines simultaneously.
 type Codec struct {
-	typeName *name
-	schema   string
+	typeName        *name
+	schema          string
+	canonicalSchema string
 
 	nativeFromTextual func([]byte) (interface{}, []byte, error)
 	binaryFromNative  func([]byte, interface{}) ([]byte, error)
@@ -168,6 +169,9 @@ func NewCodec(schemaSpecification string) (*Codec, error) {
 			return nil, fmt.Errorf("cannot remarshal schema: %s", err)
 		}
 		c.schema = string(compact)
+
+		// At this point we know we have a valid json and a valid schema
+		c.canonicalSchema = parsingCanonicalForm(schema)
 	}
 	return c, err
 }
@@ -357,6 +361,11 @@ func (c *Codec) TextualFromNative(buf []byte, datum interface{}) ([]byte, error)
 //     }
 func (c *Codec) Schema() string {
 	return c.schema
+}
+
+// CanonicalSchema returns the Parsing Canonical Form according to the specification
+func (c *Codec) CanonicalSchema() string {
+	return c.canonicalSchema
 }
 
 // convert a schema data structure to a codec, prefixing with specified


### PR DESCRIPTION
Copying text from [here](https://github.com/karrick/goavro/pull/14) for reference.

Thanks @karrick 💯

-- 

This change-set adds generation of "Parsing Canonical Form" according to the specification.

The motivation for this is to allow easy calculation of fingerprints. This also paves the path for implementation of "Single-object encoding".

Currently the canonical form is generated upon creation of the codec. I went back and forth between lazy generation of it upon the first call (and then caching it) or generating it by default. This PR does the latter.

Another point I'm wondering is weather elimination of extra whitespace in `Codec.schema` is necessary any more; If not, we could remove that and speed up the Codec initialization further by one less `json.Marshall` (and make benchmarks happy).

The test cases are brought from the reference implementation; interestingly, some of them fail with goavro's Codec generation, which I have amended to comply with goavro's current behavior and not to mix multiple change-sets in one PR.