### PR TITLE
accept strings as values for fixed fields

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -98,8 +98,22 @@ func testBinaryDecodePass(t *testing.T, schema string, datum interface{}, encode
 	}
 
 	// for testing purposes, to prevent big switch statement, convert each to
-	// string and compare.
-	if actual, expected := fmt.Sprintf("%v", value), fmt.Sprintf("%v", datum); actual != expected {
+	// string and compare. except for byte slices: we turn those straight into
+	// strings.
+	var actual, expected string
+	switch value.(type) {
+	case []byte:
+		actual = string(value.([]byte))
+	default:
+		actual = fmt.Sprintf("%v", value)
+	}
+	switch datum.(type) {
+	case []byte:
+		expected = string(datum.([]byte))
+	default:
+		expected = fmt.Sprintf("%v", datum)
+	}
+	if actual != expected {
 		t.Errorf("schema: %s; Datum: %v; Actual: %#v; Expected: %#v", schema, datum, actual, expected)
 	}
 }

--- a/fixed.go
+++ b/fixed.go
@@ -51,7 +51,18 @@ func makeFixedCodec(st map[string]*Codec, enclosingNamespace string, schemaMap m
 	}
 
 	c.binaryFromNative = func(buf []byte, datum interface{}) ([]byte, error) {
-		someBytes, ok := datum.([]byte)
+		var (
+			someBytes []byte
+			ok        = true
+		)
+		switch datum.(type) {
+		case []byte:
+			someBytes = datum.([]byte)
+		case string:
+			someBytes = []byte(datum.(string))
+		default:
+			ok = false
+		}
 		if !ok {
 			return nil, fmt.Errorf("cannot encode binary fixed %q: expected []byte; received: %T", c.typeName, datum)
 		}

--- a/fixed_test.go
+++ b/fixed_test.go
@@ -64,6 +64,7 @@ func TestFixedEncodeWrongSize(t *testing.T) {
 
 func TestFixedEncode(t *testing.T) {
 	testBinaryCodecPass(t, `{"type":"fixed","name":"foo","size":4}`, []byte("abcd"), []byte("abcd"))
+	testBinaryCodecPass(t, `{"type":"fixed","name":"foo","size":4}`, string("abcd"), []byte("abcd"))
 }
 
 func TestFixedTextCodec(t *testing.T) {

--- a/record_test.go
+++ b/record_test.go
@@ -418,6 +418,10 @@ func TestRecordFieldUnionInvalidDefaultValue(t *testing.T) {
 		"default value ought to encode using field schema")
 }
 
+func TestRecordFieldFixedDefaultValue(t *testing.T) {
+	testSchemaValid(t, `{"type": "record", "name": "r1", "fields":[{"name": "f1", "type": {"type": "fixed", "name": "fix", "size": 1}, "default": "\u0001"}]}`)
+}
+
 func TestRecordRecursiveRoundTrip(t *testing.T) {
 	codec, err := NewCodec(`
 {
@@ -534,7 +538,7 @@ func ExampleBinaryFromNative() {
 			"LongList": map[string]interface{}{
 				"next": map[string]interface{}{
 					"LongList": map[string]interface{}{
-					// NOTE: May omit fields when using default value
+						// NOTE: May omit fields when using default value
 					},
 				},
 			},
@@ -620,7 +624,7 @@ func ExampleTextualFromNative() {
 			"LongList": map[string]interface{}{
 				"next": map[string]interface{}{
 					"LongList": map[string]interface{}{
-					// NOTE: May omit fields when using default value
+						// NOTE: May omit fields when using default value
 					},
 				},
 			},


### PR DESCRIPTION
This is particularly important for default values, as those are
described as strings in the schema.

Fixes https://github.com/linkedin/goavro/issues/112