### PR TITLE
Add logicalTypes

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -179,9 +179,10 @@ func newSymbolTable() map[string]*Codec {
 			nativeFromTextual: stringNativeFromTextual,
 			textualFromNative: stringTextualFromNative,
 		},
-		// Start of logical types using format typeName.logicalType
+		// Start of compiled logical types using format typeName.logicalType where there is
+		// no dependence on schema.
 		"long.timestamp-millis": {
-			typeName:          &name{"timestamp-millis", nullNamespace},
+			typeName:          &name{"long.timestamp-millis", nullNamespace},
 			schemaOriginal:    "long",
 			schemaCanonical:   "long",
 			nativeFromTextual: timeStampMillisToNative(longNativeFromTextual),
@@ -190,7 +191,7 @@ func newSymbolTable() map[string]*Codec {
 			textualFromNative: timeStampMillisFromNative(longTextualFromNative),
 		},
 		"int.date": {
-			typeName:          &name{"date", nullNamespace},
+			typeName:          &name{"int.date", nullNamespace},
 			schemaOriginal:    "int",
 			schemaCanonical:   "int",
 			nativeFromTextual: dateToNative(intNativeFromTextual),
@@ -445,7 +446,7 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 	}
 
 	// There are only a small handful of complex Avro data types.
-	switch typeName {
+	switch searchType {
 	case "array":
 		return makeArrayCodec(st, enclosingNamespace, schemaMap)
 	case "enum":
@@ -456,6 +457,8 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 		return makeMapCodec(st, enclosingNamespace, schemaMap)
 	case "record":
 		return makeRecordCodec(st, enclosingNamespace, schemaMap)
+	case "bytes.decimal":
+		return makeDecimalBytesCodec(st, enclosingNamespace, schemaMap)
 	default:
 		return nil, fmt.Errorf("unknown type name: %q", searchType)
 	}

--- a/codec.go
+++ b/codec.go
@@ -199,14 +199,14 @@ func newSymbolTable() map[string]*Codec {
 			nativeFromBinary:  timeStampMicrosToNative(longNativeFromBinary),
 			textualFromNative: timeStampMicrosFromNative(longTextualFromNative),
 		},
-		"long.time-millis": {
-			typeName:          &name{"long.time-millis", nullNamespace},
-			schemaOriginal:    "long",
-			schemaCanonical:   "long",
-			nativeFromTextual: timeMillisToNative(longNativeFromTextual),
-			binaryFromNative:  timeMillisFromNative(longBinaryFromNative),
-			nativeFromBinary:  timeMillisToNative(longNativeFromBinary),
-			textualFromNative: timeMillisFromNative(longTextualFromNative),
+		"int.time-millis": {
+			typeName:          &name{"int.time-millis", nullNamespace},
+			schemaOriginal:    "int",
+			schemaCanonical:   "int",
+			nativeFromTextual: timeMillisToNative(intNativeFromTextual),
+			binaryFromNative:  timeMillisFromNative(intBinaryFromNative),
+			nativeFromBinary:  timeMillisToNative(intNativeFromBinary),
+			textualFromNative: timeMillisFromNative(intTextualFromNative),
 		},
 		"long.time-micros": {
 			typeName:          &name{"long.time-micros", nullNamespace},
@@ -488,8 +488,6 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 		return makeDecimalBytesCodec(st, enclosingNamespace, schemaMap)
 	case "fixed.decimal":
 		return makeDecimalFixedCodec(st, enclosingNamespace, schemaMap)
-	case "fixed.duration":
-		return makeDurationFixedCodec(st, enclosingNamespace, schemaMap)
 	default:
 		return nil, fmt.Errorf("unknown type name: %q", searchType)
 	}

--- a/codec.go
+++ b/codec.go
@@ -459,6 +459,8 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 		return makeRecordCodec(st, enclosingNamespace, schemaMap)
 	case "bytes.decimal":
 		return makeDecimalBytesCodec(st, enclosingNamespace, schemaMap)
+	case "fixed.decimal":
+		return makeDecimalFixedCodec(st, enclosingNamespace, schemaMap)
 	default:
 		return nil, fmt.Errorf("unknown type name: %q", searchType)
 	}

--- a/codec.go
+++ b/codec.go
@@ -189,6 +189,15 @@ func newSymbolTable() map[string]*Codec {
 			nativeFromBinary:  timeStampMillisToNative(longNativeFromBinary),
 			textualFromNative: timeStampMillisFromNative(longTextualFromNative),
 		},
+		"int.date": {
+			typeName:          &name{"date", nullNamespace},
+			schemaOriginal:    "int",
+			schemaCanonical:   "int",
+			nativeFromTextual: dateToNative(intNativeFromTextual),
+			binaryFromNative:  dateFromNative(intBinaryFromNative),
+			nativeFromBinary:  dateToNative(intNativeFromBinary),
+			textualFromNative: dateFromNative(intTextualFromNative),
+		},
 	}
 }
 
@@ -448,7 +457,7 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 	case "record":
 		return makeRecordCodec(st, enclosingNamespace, schemaMap)
 	default:
-		return nil, fmt.Errorf("unknown type name: %q", typeName)
+		return nil, fmt.Errorf("unknown type name: %q", searchType)
 	}
 }
 

--- a/codec.go
+++ b/codec.go
@@ -190,6 +190,33 @@ func newSymbolTable() map[string]*Codec {
 			nativeFromBinary:  timeStampMillisToNative(longNativeFromBinary),
 			textualFromNative: timeStampMillisFromNative(longTextualFromNative),
 		},
+		"long.timestamp-micros": {
+			typeName:          &name{"long.timestamp-micros", nullNamespace},
+			schemaOriginal:    "long",
+			schemaCanonical:   "long",
+			nativeFromTextual: timeStampMicrosToNative(longNativeFromTextual),
+			binaryFromNative:  timeStampMicrosFromNative(longBinaryFromNative),
+			nativeFromBinary:  timeStampMicrosToNative(longNativeFromBinary),
+			textualFromNative: timeStampMicrosFromNative(longTextualFromNative),
+		},
+		"long.time-millis": {
+			typeName:          &name{"long.time-millis", nullNamespace},
+			schemaOriginal:    "long",
+			schemaCanonical:   "long",
+			nativeFromTextual: timeMillisToNative(longNativeFromTextual),
+			binaryFromNative:  timeMillisFromNative(longBinaryFromNative),
+			nativeFromBinary:  timeMillisToNative(longNativeFromBinary),
+			textualFromNative: timeMillisFromNative(longTextualFromNative),
+		},
+		"long.time-micros": {
+			typeName:          &name{"long.time-micros", nullNamespace},
+			schemaOriginal:    "long",
+			schemaCanonical:   "long",
+			nativeFromTextual: timeMicrosToNative(longNativeFromTextual),
+			binaryFromNative:  timeMicrosFromNative(longBinaryFromNative),
+			nativeFromBinary:  timeMicrosToNative(longNativeFromBinary),
+			textualFromNative: timeMicrosFromNative(longTextualFromNative),
+		},
 		"int.date": {
 			typeName:          &name{"int.date", nullNamespace},
 			schemaOriginal:    "int",
@@ -461,6 +488,8 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 		return makeDecimalBytesCodec(st, enclosingNamespace, schemaMap)
 	case "fixed.decimal":
 		return makeDecimalFixedCodec(st, enclosingNamespace, schemaMap)
+	case "fixed.duration":
+		return makeDurationFixedCodec(st, enclosingNamespace, schemaMap)
 	default:
 		return nil, fmt.Errorf("unknown type name: %q", searchType)
 	}

--- a/doc.go
+++ b/doc.go
@@ -25,7 +25,7 @@ Usage Example:
               "type": "record",
               "name": "LongList",
               "fields" : [
-                {"name": "next", "type": ["null", "LongList"], "default": null}
+	      {"name": "next", "type": ["null", "LongList", {"type": "long", "logicalType": "timestamp-millis"}], "default": null}
               ]
             }`)
         if err != nil {

--- a/logical_type.go
+++ b/logical_type.go
@@ -201,7 +201,8 @@ func decimalBytesToNative(fn toNativeFn, precision, scale int) toNativeFn {
 		i := big.NewInt(0)
 		fromSignedBytes(i, bs)
 		if i.BitLen() > 64 {
-			return nil, b, fmt.Errorf("cannot transform to native decimal, max value is 64bit but received: %dbit", i.BitLen())
+			// Avro spec specifies we return underlying type if the logicalType is invalid
+			return d, o, err
 		}
 		r := big.NewRat(i.Int64(), int64(math.Pow10(scale)))
 		return r, o, nil

--- a/logical_type.go
+++ b/logical_type.go
@@ -15,8 +15,8 @@ type fromNativeFn func([]byte, interface{}) ([]byte, error)
 // date logical type - to/from time.Time, time.UTC location
 //////////////////////////////////////////////////////////////////////////////////////////////
 func dateToNative(fn toNativeFn) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		l, b, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		l, b, err := fn(bytes)
 		if err != nil {
 			return l, b, err
 		}
@@ -48,8 +48,8 @@ func dateFromNative(fn fromNativeFn) fromNativeFn {
 // time-millis logical type - to/from time.Time, time.UTC location
 //////////////////////////////////////////////////////////////////////////////////////////////
 func timeMillisToNative(fn toNativeFn) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		l, b, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		l, b, err := fn(bytes)
 		if err != nil {
 			return l, b, err
 		}
@@ -77,8 +77,8 @@ func timeMillisFromNative(fn fromNativeFn) fromNativeFn {
 // time-micros logical type - to/from time.Time, time.UTC location
 //////////////////////////////////////////////////////////////////////////////////////////////
 func timeMicrosToNative(fn toNativeFn) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		l, b, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		l, b, err := fn(bytes)
 		if err != nil {
 			return l, b, err
 		}
@@ -106,8 +106,8 @@ func timeMicrosFromNative(fn fromNativeFn) fromNativeFn {
 // timestamp-millis logical type - to/from time.Time, time.UTC location
 //////////////////////////////////////////////////////////////////////////////////////////////
 func timeStampMillisToNative(fn toNativeFn) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		l, b, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		l, b, err := fn(bytes)
 		if err != nil {
 			return l, b, err
 		}
@@ -136,8 +136,8 @@ func timeStampMillisFromNative(fn fromNativeFn) fromNativeFn {
 // timestamp-micros logical type - to/from time.Time, time.UTC location
 //////////////////////////////////////////////////////////////////////////////////////////////
 func timeStampMicrosToNative(fn toNativeFn) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		l, b, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		l, b, err := fn(bytes)
 		if err != nil {
 			return l, b, err
 		}
@@ -189,23 +189,23 @@ func makeDecimalBytesCodec(st map[string]*Codec, enclosingNamespace string, sche
 }
 
 func decimalBytesToNative(fn toNativeFn, precision, scale int) toNativeFn {
-	return func(b []byte) (interface{}, []byte, error) {
-		d, o, err := fn(b)
+	return func(bytes []byte) (interface{}, []byte, error) {
+		d, b, err := fn(bytes)
 		if err != nil {
-			return d, o, err
+			return d, b, err
 		}
 		bs, ok := d.([]byte)
 		if !ok {
-			return nil, b, fmt.Errorf("cannot transform to native decimal, expected []byte, received %T", d)
+			return nil, bytes, fmt.Errorf("cannot transform to native decimal, expected []byte, received %T", d)
 		}
 		i := big.NewInt(0)
 		fromSignedBytes(i, bs)
 		if i.BitLen() > 64 {
 			// Avro spec specifies we return underlying type if the logicalType is invalid
-			return d, o, err
+			return d, b, err
 		}
 		r := big.NewRat(i.Int64(), int64(math.Pow10(scale)))
-		return r, o, nil
+		return r, b, nil
 	}
 }
 

--- a/logical_type.go
+++ b/logical_type.go
@@ -2,15 +2,17 @@ package goavro
 
 import (
 	"fmt"
+	"math"
+	"math/big"
 	"time"
 )
 
 type toNativeFn func([]byte) (interface{}, []byte, error)
 type fromNativeFn func([]byte, interface{}) ([]byte, error)
 
-///////////////////////////////////////////////
-// date logical type - to/from UTC
-///////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////
+// date logical type - to/from time.Time, time.UTC location
+//////////////////////////////////////////////////////////////////////////////////////////////
 func dateToNative(fn toNativeFn) toNativeFn {
 	return func(b []byte) (interface{}, []byte, error) {
 		l, b, err := fn(b)
@@ -41,9 +43,9 @@ func dateFromNative(fn fromNativeFn) fromNativeFn {
 	}
 }
 
-///////////////////////////////////////////////
-// timestamp-millis logical type - to/from UTC
-///////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////
+// timestamp-millis logical type - to/from time.Time, time.UTC location
+//////////////////////////////////////////////////////////////////////////////////////////////
 func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 	return func(b []byte) (interface{}, []byte, error) {
 		l, b, err := fn(b)
@@ -69,4 +71,119 @@ func timeStampMillisFromNative(fn fromNativeFn) fromNativeFn {
 		millisecs := t.UnixNano() / 1e6
 		return fn(b, millisecs)
 	}
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+// decimal logical-type - byte/fixed - to/from math/big.Rat
+// two's complement algorithm taken from:
+// https://groups.google.com/d/msg/golang-nuts/TV4bRVrHZUw/UcQt7S4IYlcJ by rog
+/////////////////////////////////////////////////////////////////////////////////////////////
+type makeCodecFn func(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}) (*Codec, error)
+
+var one = big.NewInt(1)
+
+func makeDecimalBytesCodec(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}) (*Codec, error) {
+	schemaMap["name"] = "bytes.decimal"
+	c, err := registerNewCodec(st, schemaMap, enclosingNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("Bytes ought to have valid name: %s", err)
+	}
+	precision := schemaMap["precision"]
+	scale := schemaMap["scale"]
+	p := int(precision.(float64))
+	s := int(scale.(float64))
+	c.binaryFromNative = decimalBytesFromNative(bytesBinaryFromNative, p, s)
+	c.textualFromNative = decimalBytesFromNative(bytesTextualFromNative, p, s)
+	c.nativeFromBinary = decimalBytesToNative(bytesNativeFromBinary, p, s)
+	c.nativeFromTextual = decimalBytesToNative(bytesNativeFromTextual, p, s)
+	return c, nil
+}
+
+func decimalBytesToNative(fn toNativeFn, precision, scale int) toNativeFn {
+	return func(b []byte) (interface{}, []byte, error) {
+		d, o, err := fn(b)
+		if err != nil {
+			return d, o, err
+		}
+		bs, ok := d.([]byte)
+		if !ok {
+			return nil, b, fmt.Errorf("cannot transform to native decimal, expected []byte, received %T", d)
+		}
+		i := big.NewInt(0)
+		fromSignedBytes(i, bs)
+		if i.BitLen() > 64 {
+			return nil, b, fmt.Errorf("cannot transform to native decimal, max value is 64bit but received: %dbit", i.BitLen())
+		}
+		r := big.NewRat(i.Int64(), int64(math.Pow10(scale)))
+		return r, o, nil
+	}
+}
+
+func decimalBytesFromNative(fn fromNativeFn, precision, scale int) fromNativeFn {
+	return func(b []byte, d interface{}) ([]byte, error) {
+		r, ok := d.(*big.Rat)
+		if !ok {
+			return nil, fmt.Errorf("cannot transform to bytes, expected *big.Rat, received %T", d)
+		}
+		if precision < 0 {
+			return nil, fmt.Errorf("cannot transform to bytes, expected precision to be greater than 0")
+		}
+		if scale < 0 || scale > precision {
+			return nil, fmt.Errorf("cannot transform to bytes, expected scale to be 0 or scale to be greater than precision")
+		}
+		denomdigits := len(r.Denom().String())
+		// we reduce accuracy to precision by dividing and multiplying by digit length
+		i := big.NewInt(0).Div(r.Num().Mul(r.Num(), big.NewInt(int64(math.Pow10(denomdigits)))), r.Denom())
+		// we create a new bigint and copy the original so we can use abs to check digit length
+		checksign := big.NewInt(0)
+		checksign.Set(i)
+		digits := len(checksign.Abs(checksign).String())
+		out := big.NewInt(0)
+		precnum := i
+		if digits-precision > 0 {
+			precnum = out.Mul(out.Div(i, big.NewInt(int64(math.Pow10(digits-precision)))), big.NewInt(int64(math.Pow10(digits-precision))))
+		}
+		bout, err := toSignedBytes(precnum)
+		if err != nil {
+			return nil, err
+		}
+		return fn(b, bout)
+	}
+
+}
+
+// fromSignedBytes sets the value of n to the big-endian two's complement
+// value stored in the given data. If data[0]&80 != 0, the number
+// is negative. If data is empty, the result will be 0.
+func fromSignedBytes(n *big.Int, data []byte) {
+	n.SetBytes(data)
+	if len(data) > 0 && data[0]&0x80 > 0 {
+		n.Sub(n, new(big.Int).Lsh(one, uint(len(data))*8))
+	}
+}
+
+// toSignedBytes returns the big-endian two's complement
+// form of n.
+func toSignedBytes(n *big.Int) ([]byte, error) {
+	switch n.Sign() {
+	case 0:
+		return []byte{0}, nil
+	case 1:
+		b := n.Bytes()
+		if b[0]&0x80 > 0 {
+			b = append([]byte{0}, b...)
+		}
+		return b, nil
+	case -1:
+		length := uint(n.BitLen()/8+1) * 8
+		b := new(big.Int).Add(n, new(big.Int).Lsh(one, length)).Bytes()
+		// When the most significant bit is on a byte
+		// boundary, we can get some extra significant
+		// bits, so strip them off when that happens.
+		if len(b) >= 2 && b[0] == 0xff && b[1]&0x80 != 0 {
+			b = b[1:]
+		}
+		return b, nil
+	}
+	return nil, fmt.Errorf("toSignedBytes: error big.Int.Sign() returned unexpected value")
 }

--- a/logical_type.go
+++ b/logical_type.go
@@ -17,18 +17,28 @@ func dateToNative(fn toNativeFn) toNativeFn {
 		if err != nil {
 			return l, b, err
 		}
-		i, ok := l.(int)
+		i, ok := l.(int32)
 		if !ok {
-			// This error condition will not trigger with the existing longX functions as they only error on short buffer error
-			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
+			return l, b, fmt.Errorf("cannot transform to native date, expected int, received %t", l)
 		}
-		t := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i).UTC()
+		t := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, int(i)).UTC()
 		return t, b, nil
 	}
 }
 
 func dateFromNative(fn fromNativeFn) fromNativeFn {
-	return nil
+	return func(b []byte, d interface{}) ([]byte, error) {
+		t, ok := d.(time.Time)
+		if !ok {
+			return nil, fmt.Errorf("cannot transform to binary date, expected time.Time, received %T", d)
+		}
+		// The number of days calculation is incredibly naive we take the time.Duration
+		// between the given time and unix epoch and divide that by (24 * time.Hour)
+		// This accuracy seems acceptable given the relation to unix epoch for now
+		// TODO: replace with a better method
+		numDays := t.Sub(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).Nanoseconds() / (24 * time.Hour.Nanoseconds())
+		return fn(b, numDays)
+	}
 }
 
 ///////////////////////////////////////////////

--- a/logical_type.go
+++ b/logical_type.go
@@ -39,7 +39,7 @@ func dateFromNative(fn fromNativeFn) fromNativeFn {
 		// between the given time and unix epoch and divide that by (24 * time.Hour)
 		// This accuracy seems acceptable given the relation to unix epoch for now
 		// TODO: replace with a better method
-		numDays := t.Sub(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).Nanoseconds() / (24 * time.Hour.Nanoseconds())
+		numDays := t.UnixNano() / int64(24*time.Hour)
 		return fn(b, numDays)
 	}
 }
@@ -68,7 +68,7 @@ func timeMillisFromNative(fn fromNativeFn) fromNativeFn {
 		if !ok {
 			return nil, fmt.Errorf("cannot transform to binary time-millis, expected time.Duration, received %T", d)
 		}
-		duration := int32(t.Nanoseconds() / 1e6)
+		duration := int32(t.Nanoseconds() / int64(time.Millisecond))
 		return fn(b, duration)
 	}
 }
@@ -97,7 +97,7 @@ func timeMicrosFromNative(fn fromNativeFn) fromNativeFn {
 		if !ok {
 			return nil, fmt.Errorf("cannot transform to binary time-micros, expected time.Duration, received %T", d)
 		}
-		duration := t.Nanoseconds() / 1e3
+		duration := t.Nanoseconds() / int64(time.Microsecond)
 		return fn(b, duration)
 	}
 }
@@ -115,8 +115,8 @@ func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 		if !ok {
 			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
 		}
-		secs := i / 1e3
-		nanosecs := i - (secs * 1e3)
+		secs := i / int64(time.Microsecond)
+		nanosecs := i - (secs * int64(time.Microsecond))
 		return time.Unix(secs, nanosecs).UTC(), b, nil
 	}
 }
@@ -127,7 +127,7 @@ func timeStampMillisFromNative(fn fromNativeFn) fromNativeFn {
 		if !ok {
 			return nil, fmt.Errorf("cannot transform binary timestamp-millis, expected time.Time, received %T", d)
 		}
-		millisecs := t.UnixNano() / 1e6
+		millisecs := t.UnixNano() / int64(time.Millisecond)
 		return fn(b, millisecs)
 	}
 }
@@ -145,8 +145,8 @@ func timeStampMicrosToNative(fn toNativeFn) toNativeFn {
 		if !ok {
 			return l, b, fmt.Errorf("cannot transform native timestamp-micros, expected int64, received %t", l)
 		}
-		secs := i / 1e6
-		nanosecs := i - (secs * 1e6)
+		secs := i / int64(time.Millisecond)
+		nanosecs := i - (secs * int64(time.Millisecond))
 		return time.Unix(secs, nanosecs).UTC(), b, nil
 	}
 }
@@ -157,7 +157,7 @@ func timeStampMicrosFromNative(fn fromNativeFn) fromNativeFn {
 		if !ok {
 			return nil, fmt.Errorf("cannot transform binary timestamp-micros, expected time.Time, received %T", d)
 		}
-		microsecs := t.UnixNano() / 1e3
+		microsecs := t.UnixNano() / int64(time.Microsecond)
 		return fn(b, microsecs)
 	}
 }

--- a/logical_type.go
+++ b/logical_type.go
@@ -9,6 +9,29 @@ type toNativeFn func([]byte) (interface{}, []byte, error)
 type fromNativeFn func([]byte, interface{}) ([]byte, error)
 
 ///////////////////////////////////////////////
+// date logical type - to/from UTC
+///////////////////////////////////////////////
+func dateToNative(fn toNativeFn) toNativeFn {
+	return func(b []byte) (interface{}, []byte, error) {
+		l, b, err := fn(b)
+		if err != nil {
+			return l, b, err
+		}
+		i, ok := l.(int)
+		if !ok {
+			// This error condition will not trigger with the existing longX functions as they only error on short buffer error
+			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
+		}
+		t := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i).UTC()
+		return t, b, nil
+	}
+}
+
+func dateFromNative(fn fromNativeFn) fromNativeFn {
+	return nil
+}
+
+///////////////////////////////////////////////
 // timestamp-millis logical type - to/from UTC
 ///////////////////////////////////////////////
 func timeStampMillisToNative(fn toNativeFn) toNativeFn {
@@ -19,10 +42,11 @@ func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int64)
 		if !ok {
-			// This error condition will not trigger with the existing longX functions as they only error on short buffer error
 			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
 		}
-		return time.Unix(i, 0).UTC(), b, nil
+		secs := i / 1e3
+		nanosecs := i - (secs * 1e3)
+		return time.Unix(secs, nanosecs).UTC(), b, nil
 	}
 }
 
@@ -32,6 +56,7 @@ func timeStampMillisFromNative(fn fromNativeFn) fromNativeFn {
 		if !ok {
 			return nil, fmt.Errorf("cannot transform binary timestamp-millis, expected time.Time, received %T", d)
 		}
-		return fn(b, t.Unix())
+		millisecs := t.UnixNano() / 1e6
+		return fn(b, millisecs)
 	}
 }

--- a/logical_type.go
+++ b/logical_type.go
@@ -8,9 +8,9 @@ import (
 type toNativeFn func([]byte) (interface{}, []byte, error)
 type fromNativeFn func([]byte, interface{}) ([]byte, error)
 
-//////////////////////////////////////////
-// timestamp-millis logical type support
-//////////////////////////////////////////
+///////////////////////////////////////////////
+// timestamp-millis logical type - to/from UTC
+///////////////////////////////////////////////
 func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 	return func(b []byte) (interface{}, []byte, error) {
 		l, b, err := fn(b)
@@ -19,9 +19,10 @@ func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int64)
 		if !ok {
+			// This error condition will not trigger with the existing longX functions as they only error on short buffer error
 			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
 		}
-		return time.Unix(i, 0), b, nil
+		return time.Unix(i, 0).UTC(), b, nil
 	}
 }
 

--- a/logical_type.go
+++ b/logical_type.go
@@ -1,0 +1,36 @@
+package goavro
+
+import (
+	"fmt"
+	"time"
+)
+
+type toNativeFn func([]byte) (interface{}, []byte, error)
+type fromNativeFn func([]byte, interface{}) ([]byte, error)
+
+//////////////////////////////////////////
+// timestamp-millis logical type support
+//////////////////////////////////////////
+func timeStampMillisToNative(fn toNativeFn) toNativeFn {
+	return func(b []byte) (interface{}, []byte, error) {
+		l, b, err := fn(b)
+		if err != nil {
+			return l, b, err
+		}
+		i, ok := l.(int64)
+		if !ok {
+			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
+		}
+		return time.Unix(i, 0), b, nil
+	}
+}
+
+func timeStampMillisFromNative(fn fromNativeFn) fromNativeFn {
+	return func(b []byte, d interface{}) ([]byte, error) {
+		t, ok := d.(time.Time)
+		if !ok {
+			return nil, fmt.Errorf("cannot transform binary timestamp-millis, expected time.Time, received %T", d)
+		}
+		return fn(b, t.Unix())
+	}
+}

--- a/logical_type.go
+++ b/logical_type.go
@@ -22,7 +22,7 @@ func dateToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int32)
 		if !ok {
-			return l, b, fmt.Errorf("cannot transform to native date, expected int, received %t", l)
+			return l, b, fmt.Errorf("cannot transform to native date, expected int, received %T", l)
 		}
 		t := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, int(i)).UTC()
 		return t, b, nil
@@ -55,7 +55,7 @@ func timeMillisToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int32)
 		if !ok {
-			return l, b, fmt.Errorf("cannot transform to native time.Duration, expected int, received %t", l)
+			return l, b, fmt.Errorf("cannot transform to native time.Duration, expected int, received %T", l)
 		}
 		t := time.Duration(i) * time.Millisecond
 		return t, b, nil
@@ -84,7 +84,7 @@ func timeMicrosToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int64)
 		if !ok {
-			return l, b, fmt.Errorf("cannot transform to native time.Duration, expected long, received %t", l)
+			return l, b, fmt.Errorf("cannot transform to native time.Duration, expected long, received %T", l)
 		}
 		t := time.Duration(i) * time.Microsecond
 		return t, b, nil
@@ -113,7 +113,7 @@ func timeStampMillisToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int64)
 		if !ok {
-			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %t", l)
+			return l, b, fmt.Errorf("cannot transform native timestamp-millis, expected int64, received %T", l)
 		}
 		secs := i / int64(time.Microsecond)
 		nanosecs := i - (secs * int64(time.Microsecond))
@@ -143,7 +143,7 @@ func timeStampMicrosToNative(fn toNativeFn) toNativeFn {
 		}
 		i, ok := l.(int64)
 		if !ok {
-			return l, b, fmt.Errorf("cannot transform native timestamp-micros, expected int64, received %t", l)
+			return l, b, fmt.Errorf("cannot transform native timestamp-micros, expected int64, received %T", l)
 		}
 		secs := i / int64(time.Millisecond)
 		nanosecs := i - (secs * int64(time.Millisecond))

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -13,11 +13,11 @@ func TestTimeStampMillisLogicalTypeEncode(t *testing.T) {
 	schema := `{"type": "long", "logicalType": "timestamp-millis"}`
 	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
 	testBinaryEncodeFail(t, schema, "test", "cannot transform binary timestamp-millis, expected time.Time")
-	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC), []byte("\xca\x83\xca\xbb\x08"))
+	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC), []byte("\x90\xfa\xab\xba\x91\x42"))
 }
 
 func TestTimeStampMillisLogicalTypeUnionEncode(t *testing.T) {
 	schema := `{"type": ["null", {"type": "long", "logicalType": "timestamp-millis"}]}`
 	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null timestamp-millis]")
-	testBinaryCodecPass(t, schema, Union("timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\xca\x83\xca\xbb\x08"))
+	testBinaryCodecPass(t, schema, Union("timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x90\xfa\xab\xba\x91\x42"))
 }

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -23,6 +23,44 @@ func TestTimeStampMillisLogicalTypeUnionEncode(t *testing.T) {
 	testBinaryCodecPass(t, schema, Union("long.timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x90\xfa\xab\xba\x91\x42"))
 }
 
+func TestTimeStampMicrosLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "long", "logicalType": "timestamp-micros"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform binary timestamp-micros, expected time.Time")
+	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC), []byte("\x80\x8d\xb2\xe7\xaf\xd8\x84\x04"))
+}
+
+func TestTimeStampMicrosLogicalTypeUnionEncode(t *testing.T) {
+	schema := `{"type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}`
+	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null long.timestamp-micros]")
+	testBinaryCodecPass(t, schema, Union("long.timestamp-micros", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x80\x8d\xb2\xe7\xaf\xd8\x84\x04"))
+}
+
+func TestTimeMillisLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "int", "logicalType": "time-millis"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary time-millis, expected time.Duration")
+	testBinaryCodecPass(t, schema, time.Duration(1*time.Second), []byte("\xd0\x0f"))
+}
+
+func TestTimeMillisLogicalTypeUnionEncode(t *testing.T) {
+	schema := `{"type": ["null", {"type": "int", "logicalType": "time-millis"}]}`
+	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null int.time-millis]")
+	testBinaryCodecPass(t, schema, Union("int.time-millis", time.Duration(1*time.Second)), []byte("\x02\xd0\x0f"))
+}
+
+func TestTimeMicrosLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "long", "logicalType": "time-micros"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary time-micros, expected time.Duration")
+	testBinaryCodecPass(t, schema, time.Duration(1*time.Second), []byte("\x80\x89\x7a"))
+}
+
+func TestTimeMicrosLogicalTypeUnionEncode(t *testing.T) {
+	schema := `{"type": ["null", {"type": "long", "logicalType": "time-micros"}]}`
+	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null long.time-micros]")
+	testBinaryCodecPass(t, schema, Union("long.time-micros", time.Duration(1*time.Second)), []byte("\x02\x80\x89\x7a"))
+}
 func TestDateLogicalTypeEncode(t *testing.T) {
 	schema := `{"type": "int", "logicalType": "date"}`
 	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -78,7 +78,7 @@ func TestDecimalBytesLogicalTypeEncode(t *testing.T) {
 func TestDecimalFixedLogicalTypeEncode(t *testing.T) {
 	schema := `{"type": "fixed", "size": 12, "logicalType": "decimal", "precision": 4, "scale": 2}`
 	testBinaryCodecPass(t, schema, big.NewRat(617, 50), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\xd2"))
-	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfb\x2e"))
+	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfb\x2e"))
 	testBinaryCodecPass(t, schema, big.NewRat(25, 4), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x71"))
 	testBinaryCodecPass(t, schema, big.NewRat(33, 100), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x21"))
 	schema0scale := `{"type": "fixed", "size": 12, "logicalType": "decimal", "precision": 4, "scale": 0}`

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -21,3 +21,10 @@ func TestTimeStampMillisLogicalTypeUnionEncode(t *testing.T) {
 	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null timestamp-millis]")
 	testBinaryCodecPass(t, schema, Union("timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x90\xfa\xab\xba\x91\x42"))
 }
+
+func TestDateLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "int", "logicalType": "date"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary date, expected time.Time, received string")
+	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC), []byte("\xbc\xcd\x01"))
+}

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -36,3 +36,15 @@ func TestDecimalBytesLogicalTypeEncode(t *testing.T) {
 	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\x04\xfb\x2e"))
 	testBinaryCodecPass(t, schema, big.NewRat(0, 1), []byte("\x02\x00"))
 }
+
+func TestDecimalFixedLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "fixed", "size": 12, "logicalType": "decimal", "precision": 4, "scale": 2}`
+	testBinaryCodecPass(t, schema, big.NewRat(617, 50), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\xd2"))
+	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfb\x2e"))
+	testBinaryCodecPass(t, schema, big.NewRat(25, 4), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x71"))
+	testBinaryCodecPass(t, schema, big.NewRat(33, 100), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x21"))
+	schema0scale := `{"type": "fixed", "size": 12, "logicalType": "decimal", "precision": 4, "scale": 0}`
+	// Encodes to 12 due to scale: 0
+	testBinaryEncodePass(t, schema0scale, big.NewRat(617, 50), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c"))
+	testBinaryDecodePass(t, schema0scale, big.NewRat(12, 1), []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c"))
+}

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -114,5 +114,5 @@ func ExampleUnion_logicalType() {
 	}
 	out := decoded.(map[string]interface{})
 	fmt.Printf("%#v\n", out["long.timestamp-millis"].(time.Time).String())
-	// Output: 2006-01-02 15:04:05 +0000 UTC
+	// Output: "2006-01-02 15:04:05 +0000 UTC"
 }

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -1,6 +1,7 @@
 package goavro
 
 import (
+	"math/big"
 	"testing"
 	"time"
 )
@@ -18,8 +19,8 @@ func TestTimeStampMillisLogicalTypeEncode(t *testing.T) {
 
 func TestTimeStampMillisLogicalTypeUnionEncode(t *testing.T) {
 	schema := `{"type": ["null", {"type": "long", "logicalType": "timestamp-millis"}]}`
-	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null timestamp-millis]")
-	testBinaryCodecPass(t, schema, Union("timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x90\xfa\xab\xba\x91\x42"))
+	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null long.timestamp-millis]")
+	testBinaryCodecPass(t, schema, Union("long.timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\x90\xfa\xab\xba\x91\x42"))
 }
 
 func TestDateLogicalTypeEncode(t *testing.T) {
@@ -27,4 +28,11 @@ func TestDateLogicalTypeEncode(t *testing.T) {
 	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
 	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary date, expected time.Time, received string")
 	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC), []byte("\xbc\xcd\x01"))
+}
+
+func TestDecimalBytesLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}`
+	testBinaryCodecPass(t, schema, big.NewRat(617, 50), []byte("\x04\x04\xd2"))
+	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\x04\xfb\x2e"))
+	testBinaryCodecPass(t, schema, big.NewRat(0, 1), []byte("\x02\x00"))
 }

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -1,0 +1,23 @@
+package goavro
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSchemaLogicalType(t *testing.T) {
+	testSchemaValid(t, `{"type": "long", "logicalType": "timestamp-millis"}`)
+}
+
+func TestTimeStampMillisLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "long", "logicalType": "timestamp-millis"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform binary timestamp-millis, expected time.Time")
+	testBinaryCodecPass(t, schema, time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC), []byte("\xca\x83\xca\xbb\x08"))
+}
+
+func TestTimeStampMillisLogicalTypeUnionEncode(t *testing.T) {
+	schema := `{"type": ["null", {"type": "long", "logicalType": "timestamp-millis"}]}`
+	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null timestamp-millis]")
+	testBinaryCodecPass(t, schema, Union("timestamp-millis", time.Date(2006, 1, 2, 15, 04, 05, 0, time.UTC)), []byte("\x02\xca\x83\xca\xbb\x08"))
+}


### PR DESCRIPTION
We have a need to support Avro logical types as per the Avro specification. 

I have attempted to add support in as seamless a way as possible. Implementation details to note are:

* Simple logicalTypes e.g. timestamp-millis etc. are added to the symbol table as they are unlikely to change
* Complex logicalTypes e.g. decimal which require use of the schema map are added to the complex types switch statement 
* Hopefully the above implementation adds very little overhead in terms of processing for those libraries that do not use logicalTypes.
* Support for logicalTypes extends to unions ( in fact an example is written specifically for union logicalType usage ) but in order to maintain the single string union type name, they should be referred to in the format `type.logicalType` e.g. long.timestamp-millis - this allows support of both bytes.decimal and fixed.decimal. (note: the Java library has a bug against logicalTypes in union usage: https://issues.apache.org/jira/browse/AVRO-1891)

Support for duration logicalType is not added as the Java library does not yet support this and we do not have a use case for this right now.

I would be happy to make any changes if required and hope others find this piece useful.