### PR TITLE
Fix default value functionality for union of records

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -219,3 +219,50 @@ func TestDefaultValueOughtToEncodeUsingFieldSchemaOK(t *testing.T) {
 	}`)
 
 }
+
+func TestUnionOfRecordsDefaultValueOughtToEncodeUsingFieldSchemaOK(t *testing.T) {
+
+	testSchemaValid(t, `
+	{
+		"type": "record",
+		"name": "Thing",
+		"namespace": "universe.of.things",
+		"fields": [
+			{
+				"name": "layout",
+				"type": [
+					{
+						"type": "record",
+						"name": "AnotherThing",
+						"namespace": "another.universe.of.things",
+						"fields": [
+							{
+								"name": "text",
+								"type": "string",
+								"default": "someText"
+							}
+						]
+					},
+					{
+						"type": "record",
+						"name": "AnotherThing2",
+						"namespace": "another.universe.of.things",
+						"fields": [
+							{
+								"name": "text",
+								"type": "string",
+								"default": "someOtherText"
+							}
+						]
+					}
+				],
+				"default": {
+					"another.universe.of.things.AnotherThing": {
+						"text": "someDefaultText"
+					}
+				}
+			}
+		]
+	}`)
+
+}

--- a/union.go
+++ b/union.go
@@ -72,7 +72,7 @@ func buildCodecForTypeDescribedBySlice(st map[string]*Codec, enclosingNamespace 
 		// NOTE: To support record field default values, union schema set to the
 		// type name of first member
 		// TODO: add/change to schemaCanonical below
-		schemaOriginal: codecFromIndex[0].typeName.short(),
+		schemaOriginal: codecFromIndex[0].typeName.fullName,
 
 		typeName: &name{"union", nullNamespace},
 		nativeFromBinary: func(buf []byte) (interface{}, []byte, error) {


### PR DESCRIPTION
During our dev, we are trying to create a union of Record types and we noticed that the default values were not being parsed correctly.  This would lead to the following error: `Record "universe.of.things.Thing" field "layout": default value ought to encode using field schema: cannot encode binary union: no member schema types support datum: allowed types: [another.universe.of.things.AnotherThing another.universe.of.things.AnotherThing2]`

I made a change to just use the full name instead of the short name.  The test case references records on a different namespace, which is what we've defined in our schema.