### PR TITLE
Codec's NativeFromTextual doesn't return a float32 value for a float value

### DIFF
--- a/floatingPoint.go
+++ b/floatingPoint.go
@@ -140,6 +140,9 @@ func floatingTextDecoder(buf []byte, bitSize int) (interface{}, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	if bitSize == 32 {
+		return float32(datum), buf[index:], nil
+	}
 	return datum, buf[index:], nil
 }
 

--- a/number_recover_test.go
+++ b/number_recover_test.go
@@ -1,0 +1,55 @@
+package goavro
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testPrimitiveRecoverNative(t *testing.T, schema string, value interface{}) {
+	codec, err := NewCodec(schema)
+	if err != nil {
+		t.Fatalf("Schema: %s; %s", schema, err)
+	}
+
+	// native -> binary -> native
+	binary, err := codec.BinaryFromNative(nil, value)
+	if err != nil {
+		t.Fatalf("Datum: %v; %s", value, err)
+	}
+	native, _, err := codec.NativeFromBinary(binary)
+	if err != nil {
+		t.Fatalf("Datum: %s; %s", binary, err)
+	}
+	if reflect.TypeOf(value) != reflect.TypeOf(native) {
+		t.Fatalf("Datum: %v expected type %T but was value %v of type %T", value, value, native, native)
+	}
+
+	// native -> textual -> native
+	textual, err := codec.TextualFromNative(nil, value)
+	if err != nil {
+		t.Fatalf("Datum: %v; %s", value, err)
+	}
+	native, _, err = codec.NativeFromTextual(textual)
+	if err != nil {
+		t.Fatalf("Datum: %s; %s", textual, err)
+	}
+	if reflect.TypeOf(value) != reflect.TypeOf(native) {
+		t.Fatalf("Datum: %v expected type %T but was value %v of type %T", value, value, native, native)
+	}
+}
+
+func TestPrimitiveRecoverInt(t *testing.T) {
+	testPrimitiveRecoverNative(t, `"int"`, int32(1010))
+}
+
+func TestPrimitiveRecoverLong(t *testing.T) {
+	testPrimitiveRecoverNative(t, `"long"`, int64(8128953))
+}
+
+func TestPrimitiveRecoverFloat(t *testing.T) {
+	testPrimitiveRecoverNative(t, `"float"`, float32(-8.937134))
+}
+
+func TestPrimitiveRecoverDouble(t *testing.T) {
+	testPrimitiveRecoverNative(t, `"double"`, float64(5.247290238727473))
+}


### PR DESCRIPTION
Codec NativeFromTextual is internally using strconv.ParseFloat and returning a float64 native value directly for a float typed data. This leads to an issue when the precision or comparison to the original float32 data is important.

This patch includes a fix for this problem and several test cases. Without the fix, the test would fail with 
```
--- FAIL: TestPrimitiveRecoverFloat (0.00s)
    number_recover_test.go:37: Datum: -8.937134 expected type float32 but was value -8.9371337890625 of type float64

```
By the way NativeFromBinary is returning a float32 value and does not suffer this problem.

regards, aki