### PR TITLE
Fix go.mod to include v2 in import path.

### DIFF
--- a/canonical_test.go
+++ b/canonical_test.go
@@ -3,7 +3,7 @@ package goavro_test
 import (
 	"testing"
 
-	"github.com/linkedin/goavro"
+	"github.com/linkedin/goavro/v2"
 )
 
 func TestCanonicalSchema(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/linkedin/goavro"
+	"github.com/linkedin/goavro/v2"
 )
 
 func ExampleCodecCanonicalSchema() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
-module github.com/linkedin/goavro
+module github.com/linkedin/goavro/v2
 
-require github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+require (
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+	github.com/linkedin/goavro v2.1.0+incompatible
+	gopkg.in/linkedin/goavro.v1 v1.0.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/linkedin/goavro v2.1.0+incompatible h1:DV2aUlj2xZiuxQyvag8Dy7zjY69ENjS66bWkSfdpddY=
+github.com/linkedin/goavro v2.1.0+incompatible/go.mod h1:bBCwI2eGYpUI/4820s67MElg9tdeLbINjLjiM2xZFYM=
+gopkg.in/linkedin/goavro.v1 v1.0.5 h1:BJa69CDh0awSsLUmZ9+BowBdokpduDZSM9Zk8oKHfN4=
+gopkg.in/linkedin/goavro.v1 v1.0.5/go.mod h1:Aw5GdAbizjOEl0kAMHV9iHmA8reZzW/OKuJAl4Hb9F0=


### PR DESCRIPTION
In order to comply with the import rules for go modules, the major
version must be included in the go.mod module path.