### PR TITLE
fix string encoding for multibyte runes

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -384,13 +384,15 @@ func stringTextualFromNative(buf []byte, datum interface{}) ([]byte, error) {
 	}
 	buf = append(buf, '"') // prefix buffer with double quote
 	for _, r := range someString {
-		if escaped, ok := escapeSpecialJSON(byte(r)); ok {
-			buf = append(buf, escaped...)
-			continue
-		}
-		if r < utf8.RuneSelf && unicode.IsPrint(r) {
-			buf = append(buf, byte(r))
-			continue
+		if r < utf8.RuneSelf {
+			if escaped, ok := escapeSpecialJSON(byte(r)); ok {
+				buf = append(buf, escaped...)
+				continue
+			}
+			if unicode.IsPrint(r) {
+				buf = append(buf, byte(r))
+				continue
+			}
 		}
 		// NOTE: Attempt to encode code point as UTF-16 surrogate pair
 		r1, r2 := utf16.EncodeRune(r)

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -110,6 +110,8 @@ func TestPrimitiveStringText(t *testing.T) {
 	testTextDecodeFail(t, `"string"`, []byte("\"\\ugggg\""), "invalid byte") // > 'f'
 
 	testTextCodecPass(t, `"string"`, "⌘ ", []byte("\"\\u0001\\u2318 \""))
+	testTextCodecPass(t, `"string"`, "™ ", []byte("\"\\u0001\\u2122 \""))
+	testTextCodecPass(t, `"string"`, "ℯ ", []byte("\"\\u0001\\u212F \""))
 	testTextCodecPass(t, `"string"`, "😂 ", []byte("\"\\u0001\\uD83D\\uDE02 \""))
 
 	testTextDecodeFail(t, `"string"`, []byte("\"\\"), "short buffer")


### PR DESCRIPTION
- Explicitly checks rune size before escaping JSON special characters
- Adds tests for incorrect output on current master
- Resolves #157

All tests pass locally on Go 1.12.1.