### PR TITLE
Fix example code in readme and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ func ExampleUnion() {
     if err != nil {
         fmt.Println(err)
     }
-    buf, err := codec.TextFromNative(nil, goavro.Union("string", "some string"))
+    buf, err := codec.TextualFromNative(nil, goavro.Union("string", "some string"))
     if err != nil {
         fmt.Println(err)
     }

--- a/union.go
+++ b/union.go
@@ -29,7 +29,7 @@ import (
 //        if err != nil {
 //            fmt.Println(err)
 //        }
-//        buf, err := codec.TextFromNative(nil, goavro.Union("string", "some string"))
+//        buf, err := codec.TextualFromNative(nil, goavro.Union("string", "some string"))
 //        if err != nil {
 //            fmt.Println(err)
 //        }


### PR DESCRIPTION
Happened to find, while wondering through the repo, that the example text matching `union_test.go/ExampleUnion` wouldn't compile.

Didn't see any guides for contributing or committing, but let me know if you need something done differently.