### PR TITLE
Fix default value type for int and long

### DIFF
--- a/record.go
+++ b/record.go
@@ -78,6 +78,12 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 			if err != nil {
 				return nil, fmt.Errorf("Record %q field %q: default value ought to encode using field schema: %s", c.typeName, fieldName, err)
 			}
+			switch fieldCodec.typeName.short() {
+			case "long":
+				defaultValue = int64(defaultValue.(float64))
+			case "int":
+				defaultValue = int32(defaultValue.(float64))
+			}
 			defaultValueFromName[fieldName] = defaultValue
 		}
 

--- a/record_test.go
+++ b/record_test.go
@@ -637,3 +637,20 @@ func ExampleTextualFromNative() {
 func TestRecordFieldFixedDefaultValue(t *testing.T) {
 	testSchemaValid(t, `{"type": "record", "name": "r1", "fields":[{"name": "f1", "type": {"type": "fixed", "name": "fix", "size": 1}, "default": "\u0000"}]}`)
 }
+
+func TestRecordFieldLongDefaultValue(t *testing.T) {
+	codec, err := NewCodec(`{"type": "record", "name": "r1", "fields":[{"name": "f1", "type": "long", "default": 0}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r1, _, err := codec.nativeFromTextual([]byte("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r1m := r1.(map[string]interface{})
+
+	v := r1m["f1"]
+	if _, ok := v.(int64); !ok {
+		t.Fatalf("f1 default value type is not long: %T", v)
+	}
+}


### PR DESCRIPTION
Currently default value type is float64 for ints and longs.
As a result nativeFromTextual method returns a map with key=float64(value) for default int and long values.
This patch fixes it.
