### PR TITLE
Fixed bug in caching of the "bytes.decimal" codec to include precision and scale

### DIFF
--- a/logical_type.go
+++ b/logical_type.go
@@ -231,6 +231,11 @@ func makeDecimalBytesCodec(st map[string]*Codec, enclosingNamespace string, sche
 	if err != nil {
 		return nil, fmt.Errorf("Bytes ought to have valid name: %s", err)
 	}
+
+	// Add an additional cached codec for this "bytes.decimal" keyed also by "precision" and "scale"
+	decimalSearchType := fmt.Sprintf("bytes.decimal.%d.%d", precision, scale)
+	st[decimalSearchType] = c
+
 	c.binaryFromNative = decimalBytesFromNative(bytesBinaryFromNative, toSignedBytes, precision, scale)
 	c.textualFromNative = decimalBytesFromNative(bytesTextualFromNative, toSignedBytes, precision, scale)
 	c.nativeFromBinary = nativeFromDecimalBytes(bytesNativeFromBinary, precision, scale)


### PR DESCRIPTION
There is a bug in linkedin/goavro where the codec for all logical types are being stored just by the type name (ex: "bytes.decimal"). This results in the first logical type codec being cached and the rest referencing that one. For "bytes.decimal" this results in the "precision" and "scale" for this first "bytes.decimal" in the schema being used for all "bytes.decimal" in the schema. The fix I am proposing caches "bytes.decimal" by type name, precision and scale (ex: key would be "bytes.decimal.10.2" for a "bytes.decimal" with a precision of 10 and scale of 2).