### PR TITLE
Add a simple JSON serializer

### DIFF
--- a/record.go
+++ b/record.go
@@ -298,7 +298,6 @@ func simpleRecordEncoder(buf []byte, datum interface{}, codecFromKey map[string]
 		if vm, ok := v.(map[string]interface{}); ok {
 			v = getFirstElem(vm)
 		}
-		// f := getFirstElem(v)
 		elem, err := json.Marshal(v)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal")


### PR DESCRIPTION
**What**

Add `SimpleTextualFromNative` function to simplify JSON textual representation.
This function allows to yield JSON without type information.

**Why**

As discussed in following issues, it is needed to serialize JSON without type information in some cases even if it is incompatible with Avro specs.

Fixes #167 
