### PR TITLE
Zstd and bzip2 compression support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/dsnet/compress v0.0.1
 	github.com/golang/snappy v0.0.1
+	github.com/klauspost/compress v1.10.3
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/linkedin/goavro/v2
 
 go 1.12
 
-require github.com/golang/snappy v0.0.1
+require (
+	github.com/dsnet/compress v0.0.1
+	github.com/golang/snappy v0.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,9 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
+github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
+github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/ocf.go
+++ b/ocf.go
@@ -32,6 +32,10 @@ const (
 	// CompressionBzip2Label is used when OCF blocks are compressed using the
 	// bzip2 algorithm.
 	CompressionBzip2Label = "bzip2"
+
+	// CompressionZstdLabel is used when OCF blocks are compressed using the
+	// ZStandart algorithm.
+	CompressionZstdLabel = "zstandard"
 )
 
 // compressionID are values used to specify compression algorithm used to compress
@@ -43,6 +47,7 @@ const (
 	compressionDeflate
 	compressionSnappy
 	compressionBzip2
+	compressionZstd
 )
 
 const (
@@ -88,6 +93,8 @@ func newOCFHeader(config OCFConfig) (*ocfHeader, error) {
 		header.compressionID = compressionSnappy
 	case CompressionBzip2Label:
 		header.compressionID = compressionBzip2
+	case CompressionZstdLabel:
+		header.compressionID = compressionZstd
 	default:
 		return nil, fmt.Errorf("cannot create OCF header using unrecognized compression algorithm: %q", config.CompressionName)
 	}
@@ -162,6 +169,8 @@ func readOCFHeader(ior io.Reader) (*ocfHeader, error) {
 			cID = compressionSnappy
 		case CompressionBzip2Label:
 			cID = compressionBzip2
+		case CompressionZstdLabel:
+			cID = compressionZstd
 		default:
 			return nil, fmt.Errorf("cannot read OCF header using unrecognized compression algorithm from avro.codec: %q", avroCodec)
 		}
@@ -208,6 +217,8 @@ func writeOCFHeader(header *ocfHeader, iow io.Writer) (err error) {
 		avroCodec = CompressionSnappyLabel
 	case compressionBzip2:
 		avroCodec = CompressionBzip2Label
+	case compressionZstd:
+		avroCodec = CompressionZstdLabel
 	default:
 		return fmt.Errorf("should not get here: cannot write OCF header using unrecognized compression algorithm: %d", header.compressionID)
 	}

--- a/ocf.go
+++ b/ocf.go
@@ -28,6 +28,10 @@ const (
 	// CompressionSnappyLabel is used when OCF blocks are compressed using the
 	// snappy algorithm.
 	CompressionSnappyLabel = "snappy"
+
+	// CompressionBzip2Label is used when OCF blocks are compressed using the
+	// bzip2 algorithm.
+	CompressionBzip2Label = "bzip2"
 )
 
 // compressionID are values used to specify compression algorithm used to compress
@@ -38,6 +42,7 @@ const (
 	compressionNull compressionID = iota
 	compressionDeflate
 	compressionSnappy
+	compressionBzip2
 )
 
 const (
@@ -81,6 +86,8 @@ func newOCFHeader(config OCFConfig) (*ocfHeader, error) {
 		header.compressionID = compressionDeflate
 	case CompressionSnappyLabel:
 		header.compressionID = compressionSnappy
+	case CompressionBzip2Label:
+		header.compressionID = compressionBzip2
 	default:
 		return nil, fmt.Errorf("cannot create OCF header using unrecognized compression algorithm: %q", config.CompressionName)
 	}
@@ -153,6 +160,8 @@ func readOCFHeader(ior io.Reader) (*ocfHeader, error) {
 			cID = compressionDeflate
 		case CompressionSnappyLabel:
 			cID = compressionSnappy
+		case CompressionBzip2Label:
+			cID = compressionBzip2
 		default:
 			return nil, fmt.Errorf("cannot read OCF header using unrecognized compression algorithm from avro.codec: %q", avroCodec)
 		}
@@ -197,6 +206,8 @@ func writeOCFHeader(header *ocfHeader, iow io.Writer) (err error) {
 		avroCodec = CompressionDeflateLabel
 	case compressionSnappy:
 		avroCodec = CompressionSnappyLabel
+	case compressionBzip2:
+		avroCodec = CompressionBzip2Label
 	default:
 		return fmt.Errorf("should not get here: cannot write OCF header using unrecognized compression algorithm: %d", header.compressionID)
 	}

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -248,7 +248,9 @@ func (ocfr *OCFReader) Scan() bool {
 				return false
 			}
 			ocfr.block, ocfr.rerr = ioutil.ReadAll(rc)
-			rc.Close()
+			if cerr := rc.Close(); ocfr.rerr == nil {
+			    ocfr.rerr = cerr
+			}
 			if ocfr.rerr != nil {
 				return false
 			}

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/dsnet/compress/bzip2"
 	"github.com/golang/snappy"
 )
 
@@ -80,6 +81,8 @@ func (ocfr *OCFReader) CompressionName() string {
 		return CompressionDeflateLabel
 	case compressionSnappy:
 		return CompressionSnappyLabel
+	case compressionBzip2:
+		return CompressionBzip2Label
 	default:
 		return "should not get here: unrecognized compression algorithm"
 	}
@@ -219,6 +222,21 @@ func (ocfr *OCFReader) Scan() bool {
 				return false
 			}
 			ocfr.block = decoded
+
+		case compressionBzip2:
+			rc, err := bzip2.NewReader(bytes.NewBuffer(ocfr.block), nil)
+			if err != nil {
+				ocfr.rerr = fmt.Errorf("bzip2 error: %s", err)
+				return false
+			}
+			ocfr.block, ocfr.rerr = ioutil.ReadAll(rc)
+			if ocfr.rerr != nil {
+				_ = rc.Close()
+				return false
+			}
+			if ocfr.rerr = rc.Close(); ocfr.rerr != nil {
+				return false
+			}
 
 		default:
 			ocfr.rerr = fmt.Errorf("should not get here: cannot compress block using unrecognized compression: %d", ocfr.header.compressionID)

--- a/ocf_test.go
+++ b/ocf_test.go
@@ -92,6 +92,10 @@ func TestOCFWriterCompressionSnappy(t *testing.T) {
 	testOCFRoundTrip(t, CompressionSnappyLabel)
 }
 
+func TestOCFWriterCompressionBzip2(t *testing.T) {
+	testOCFRoundTrip(t, CompressionBzip2Label)
+}
+
 func TestOCFWriterWithApplicationMetaData(t *testing.T) {
 	testOCFRoundTripWithHeaders(t, CompressionNullLabel, map[string][]byte{"foo": []byte("BOING"), "goo": []byte("zoo")})
 }

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dsnet/compress/bzip2"
 	"github.com/golang/snappy"
+	"github.com/klauspost/compress/zstd"
 )
 
 // OCFConfig is used to specify creation parameters for OCFWriter.
@@ -216,6 +217,17 @@ func (ocfw *OCFWriter) appendDataIntoBlock(data []interface{}) error {
 	case compressionBzip2:
 		bb := bytes.NewBuffer(make([]byte, 0, len(block)))
 		cw, _ := bzip2.NewWriter(bb, &bzip2.WriterConfig{Level: 9})
+		if _, err := cw.Write(block); err != nil {
+			return err
+		}
+		if err := cw.Close(); err != nil {
+			return err
+		}
+		block = bb.Bytes()
+
+	case compressionZstd:
+		bb := bytes.NewBuffer(make([]byte, 0, len(block)))
+		cw, _ := zstd.NewWriter(bb)
 		if _, err := cw.Write(block); err != nil {
 			return err
 		}


### PR DESCRIPTION
tested with avro-tools 1.9.2

```
$ avro-tools getmeta event.zstd.avro
avro.schema
          {
                "type" : "record",
                "name" : "Event",
                "fields" : [ {
                  "name" : "body",
                  "type" : "bytes"
                } ]
          }

avro.codec      zstandard
```

```
$ avro-tools getmeta event.bz2.avro
avro.schema
          {
                "type" : "record",
                "name" : "Event",
                "fields" : [ {
                  "name" : "body",
                  "type" : "bytes"
                } ]
          }

avro.codec      bzip2
```