### PR TITLE
Improve error message for decoding value

### DIFF
--- a/map.go
+++ b/map.go
@@ -204,7 +204,7 @@ func genericMapTextDecoder(buf []byte, defaultCodec *Codec, codecFromKey map[str
 		}
 		value, buf, err = fieldCodec.nativeFromTextual(buf)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%s for key: %q", err.Error(), key)
 		}
 		// set map value for key
 		mapValues[key] = value


### PR DESCRIPTION
The function `genericMapTextDecoder` can returns an error with format `cannot decode textual record %q: %s` from `nativeFromTextual`. But it not returns for which key the error occurs.

###### Example
```
cannot decode textual array: expected: '['; actual: 'n' for key: foo
```
The message above is returned when the first character for un expected array is not `[`. I added to the end of the message the value of the key for which the error occurs.