### PR TITLE
feat: support larger decimals

### DIFF
--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -144,6 +144,13 @@ func TestDecimalBytesLogicalTypeEncode(t *testing.T) {
 	testBinaryCodecPass(t, schema, big.NewRat(617, 50), []byte("\x04\x04\xd2"))
 	testBinaryCodecPass(t, schema, big.NewRat(-617, 50), []byte("\x04\xfb\x2e"))
 	testBinaryCodecPass(t, schema, big.NewRat(0, 1), []byte("\x02\x00"))
+	// Test with a large decimal of precision 77 and scale 38
+	largeDecimalSchema := `{"type": "bytes", "logicalType": "decimal", "precision": 77, "scale": 38}`
+	n, _ := new(big.Int).SetString("12345678901234567890123456789012345678911111111111111111111111111111111111111", 10)
+	d, _ := new(big.Int).SetString("100000000000000000000000000000000000000", 10)
+	largeRat := new(big.Rat).SetFrac(n, d)
+	testBinaryCodecPass(t, largeDecimalSchema, largeRat, []byte("\x40\x1b\x4b\x68\x19\x26\x11\xfa\xea\x20\x8f\xca\x21\x62\x7b\xe9\xda\xee\x32\x19\x83\x83\x95\x5d\xe8\x13\x1f\x4b\xf1\xc7\x1c\x71\xc7"))
+
 }
 
 func TestDecimalFixedLogicalTypeEncode(t *testing.T) {


### PR DESCRIPTION
This PR updates the handling for the decimal logical type to support
larger precisions and scales.

Previously, the implementation supported decimals up to 64 bits in size.

This is accomplished by updating from lossy inputs/conversions to use of `math/big` equivalents.
For example, usages of `math.Pow10()` are updated to use big.Int's `Exp()`, and similar small changes for big.Rat construction.

Additional notes:

There appears to be no mention of maximum precision/scale boundaries in the Avro specification, so this does not enforce them.  Latest spec appears to be http://avro.apache.org/docs/1.10.0/spec.html#Decimal but I checked earlier ones as well. With this change, decimal sizes are effectively bound on other factors (architecture, block size, etc).

This PR doesn't add any special checking/testing for undersized fixed types with a decimal logical type.   It seems there's an existing test (TestDecimalFixedLogicalTypeEncode) that demonstrates precision loss due to a constrained fixed type size, so it's an understood/tested behavior already.

The reason for this change is that I work with a system that can produce and consume large decimal values (~256bits), and supports Avro as a data serialization format.

I didn't see anything like a contribution guide, so if I've overlooked anything please let me know.  Thanks for maintaining such a useful library.
