### PR TITLE
fix #199: pcfObject() should add parent namespace to enum filed when no namespace filled

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -84,7 +84,7 @@ func pcfObject(jsonMap map[string]interface{}, parentNamespace string, typeLooku
 			}
 			parentNamespace = namespace
 		}
-	} else if objectType, ok := jsonMap["type"]; ok && (objectType == "record" || objectType == "enum") {
+	} else if objectType, ok := jsonMap["type"]; ok && (objectType == "record" || objectType == "enum" || objectType == "fixed") {
 		namespace = parentNamespace
 	}
 

--- a/canonical.go
+++ b/canonical.go
@@ -84,7 +84,7 @@ func pcfObject(jsonMap map[string]interface{}, parentNamespace string, typeLooku
 			}
 			parentNamespace = namespace
 		}
-	} else if objectType, ok := jsonMap["type"]; ok && objectType == "record" {
+	} else if objectType, ok := jsonMap["type"]; ok && (objectType == "record" || objectType == "enum") {
 		namespace = parentNamespace
 	}
 

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -175,6 +175,14 @@ func TestCanonicalSchema(t *testing.T) {
 			Canonical: `{"name":"x.y.z.foo","type":"fixed","size":32}`,
 		},
 		{
+			Schema:    `{"type":"record", "name":"foo", "namespace":"x.y", "fields":[{"name":"bar","type":"fixed", "doc":"foo bar", "size":32}]}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"x.y.bar","type":"fixed","size":32}]}`,
+		},
+		{
+			Schema:    `{"type":"record", "name":"foo", "namespace":"x.y", "fields":[{"name":"a.b.bar","type":"fixed", "doc":"foo bar", "size":32}]}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"a.b.bar","type":"fixed","size":32}]}`,
+		},
+		{
 			Schema:    `{ "items":{"type":"null"}, "type":"array"}`,
 			Canonical: `{"type":"array","items":"null"}`,
 		},

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -155,6 +155,18 @@ func TestCanonicalSchema(t *testing.T) {
 			Canonical: `{"name":"x.y.z.foo","type":"enum","symbols":["A1","A2"]}`,
 		},
 		{
+			Schema:    `{"type":"record", "name":"a.b.foo", "namespace":"x.y", "fields":[{"name":"bar","type":"enum","symbols":["A1","A2"]}]}`,
+			Canonical: `{"name":"a.b.foo","type":"record","fields":[{"name":"x.y.bar","type":"enum","symbols":["A1","A2"]}]}`,
+		},
+		{
+			Schema:    `{"type":"record", "name":"foo", "namespace":"x.y", "fields":[{"name":"bar","type":"enum","symbols":["A1","A2"]}]}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"x.y.bar","type":"enum","symbols":["A1","A2"]}]}`,
+		},
+		{
+			Schema:    `{"type":"record", "name":"foo", "namespace":"x.y", "fields":[{"name":"a.b.bar","type":"enum","symbols":["A1","A2"]}]}`,
+			Canonical: `{"name":"x.y.foo","type":"record","fields":[{"name":"a.b.bar","type":"enum","symbols":["A1","A2"]}]}`,
+		},
+		{
 			Schema:    `{"name":"foo","type":"fixed","size":15}`,
 			Canonical: `{"name":"foo","type":"fixed","size":15}`,
 		},


### PR DESCRIPTION
according to avro spec https://avro.apache.org/docs/1.8.2/…spec.html#Parsing+Canonical+Form+for+Schemas, enum should be managed like records, parent namespace should be used to generate canonical form