### PR TITLE
complete support for standard/simple json and an avro tool

### DIFF
--- a/array.go
+++ b/array.go
@@ -16,13 +16,13 @@ import (
 	"reflect"
 )
 
-func makeArrayCodec(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}) (*Codec, error) {
+func makeArrayCodec(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}, cb *codecBuilder) (*Codec, error) {
 	// array type must have items
 	itemSchema, ok := schemaMap["items"]
 	if !ok {
 		return nil, fmt.Errorf("Array ought to have items key")
 	}
-	itemCodec, err := buildCodec(st, enclosingNamespace, itemSchema)
+	itemCodec, err := buildCodec(st, enclosingNamespace, itemSchema, cb)
 	if err != nil {
 		return nil, fmt.Errorf("Array items ought to be valid Avro type: %s", err)
 	}

--- a/examples/roundtrip/main.go
+++ b/examples/roundtrip/main.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	bin "encoding/binary"
+	hex "encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/linkedin/goavro/v2"
+)
+
+// roundtrip is a tool for checking avro
+//
+// incoming data is assumed to be standard json
+// incoming json is required to be one json object per line
+// use `jq -c .` if you need to.  get it into one line
+//
+// you can write out your avro in binary form and stop there
+// which is useful for cases where you might want to send it off into other tools
+//
+// you can also do a roundtrip of decode/encode
+// which allows you to see if your avro schema matches your expectations
+//
+// If you want to use an encoded schemaid then specify a schemid with -sid
+// it will be encoded per a common standard (one null byte, 16 bytes of schemaid)
+// Its NOT the standard SOE
+// SOE should be added
+// Probably OCF should be added too
+//
+// EXAMPLE
+//
+// kubectl get events -w -o json | jq -c .  | ./roundtrip -sid aa6b1ca0e1ee2d885bfbc747f4a4011b -avsc event-schema.json ) -rt
+
+func MakeAvroHeader(schemaid string) (header []byte, err error) {
+	dst, err := hex.DecodeString(schemaid)
+	if err != nil {
+		return
+	}
+	header = append(header, byte(0))
+	header = append(header, dst...)
+	return
+}
+func main() {
+
+	var avsc = flag.String("avsc", "", "the avro schema")
+	var data = flag.String("data", "-", "(default stdin) the data that corresponds to the avro schema or error - ONE LINE PER DATA ITEM")
+	var schemaid = flag.String("sid", "", "the schemaid which is normally the md5hash of rht schema itself")
+	var roundtrip = flag.Bool("rt", false, "do full round trip to try to rebuild the original data string")
+	var xxd = flag.String("bin", "", "write out the binary data to this file - look at it with xxd if you want to")
+	var appendBin = flag.Bool("append", false, "append to the output binary file instead of trunc")
+
+	flag.Parse()
+
+	_avsc, err := ioutil.ReadFile(*avsc)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to read avsc file:%s:error:%v:", *avsc, err))
+	}
+
+	codec, err := goavro.NewCodecForStandardJSON(string(_avsc))
+	if err != nil {
+		panic(err)
+	}
+
+	var _data io.Reader
+	if *data == "-" {
+		_data = os.Stdin
+	} else {
+		file, err := os.Open(*data)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to open data file:%s:error:%v:", *data, err))
+		}
+		_data = bufio.NewReader(file)
+		defer file.Close()
+	}
+
+	binOut := struct {
+		file *os.File
+		do   bool
+	}{}
+	if len(*xxd) > 0 {
+		bits := os.O_WRONLY | os.O_CREATE
+		if *appendBin {
+			bits |= os.O_APPEND
+		} else {
+			bits |= os.O_TRUNC
+		}
+
+		binOut.file, err = os.OpenFile(*xxd, bits, 0600)
+		if err != nil {
+			panic(err)
+		}
+		defer binOut.file.Close()
+		binOut.do = true
+	}
+
+	scanner := bufio.NewScanner(_data)
+
+	for scanner.Scan() {
+
+		dat := scanner.Text()
+		if len(dat) == 0 {
+			fmt.Println("skipping empty line")
+			continue
+		}
+
+		fmt.Println("RT in")
+		fmt.Println(dat)
+
+		textual := []byte(dat)
+
+		fmt.Printf("encoding for schemaid:%s:\n", *schemaid)
+		avroNative, _, err := codec.NativeFromTextual(textual)
+
+		if err != nil {
+			fmt.Println(dat)
+			panic(err)
+		}
+
+		header, err := MakeAvroHeader(*schemaid)
+		if err != nil {
+			fmt.Println(string(textual))
+			panic(err)
+		}
+
+		avrobin, err := codec.BinaryFromNative(nil, avroNative)
+		if err != nil {
+			fmt.Println(dat)
+			panic(err)
+		}
+
+		// trying to minimize operations within the loop
+		// so do only a quick boolean check here
+		if binOut.do {
+			for _, buf := range [][]byte{header, avrobin} {
+				err = bin.Write(binOut.file, bin.LittleEndian, buf)
+				if err != nil {
+					fmt.Println(dat)
+					panic(err)
+				}
+			}
+		}
+
+		if *roundtrip {
+			// this will scramble the order
+			// since it makes new go maps
+			// when it takes the binary into native
+			rtnativeval, _, err := codec.NativeFromBinary(avrobin)
+			if err != nil {
+				fmt.Println(dat)
+				panic(err)
+			}
+
+			// Convert native Go form to textual Avro data
+			textual, err = codec.TextualFromNative(nil, rtnativeval)
+			if err != nil {
+				fmt.Println(dat)
+				panic(err)
+			}
+
+			fmt.Println("RT out")
+			fmt.Println(string(textual))
+		}
+
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("scanner error")
+		panic(err)
+	}
+
+	fmt.Println("Done with loop - no more data")
+
+}

--- a/map.go
+++ b/map.go
@@ -17,13 +17,13 @@ import (
 	"reflect"
 )
 
-func makeMapCodec(st map[string]*Codec, namespace string, schemaMap map[string]interface{}) (*Codec, error) {
+func makeMapCodec(st map[string]*Codec, namespace string, schemaMap map[string]interface{}, cb *codecBuilder) (*Codec, error) {
 	// map type must have values
 	valueSchema, ok := schemaMap["values"]
 	if !ok {
 		return nil, errors.New("Map ought to have values key")
 	}
-	valueCodec, err := buildCodec(st, namespace, valueSchema)
+	valueCodec, err := buildCodec(st, namespace, valueSchema, cb)
 	if err != nil {
 		return nil, fmt.Errorf("Map values ought to be valid Avro type: %s", err)
 	}

--- a/record.go
+++ b/record.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 )
 
-func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}) (*Codec, error) {
+func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}, cb *codecBuilder) (*Codec, error) {
 	// NOTE: To support recursive data types, create the codec and register it
 	// using the specified name, and fill in the codec functions later.
 	c, err := registerNewCodec(st, schemaMap, enclosingNamespace)
@@ -44,7 +44,7 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 		// NOTE: field names are not registered in the symbol table, because
 		// field names are not individually addressable codecs.
 
-		fieldCodec, err := buildCodecForTypeDescribedByMap(st, c.typeName.namespace, fieldSchemaMap)
+		fieldCodec, err := buildCodec(st, c.typeName.namespace, fieldSchemaMap, cb)
 		if err != nil {
 			return nil, fmt.Errorf("Record %q field %d ought to be valid Avro named type: %s", c.typeName, i+1, err)
 		}

--- a/text_test.go
+++ b/text_test.go
@@ -61,7 +61,22 @@ func testTextDecodePass(t *testing.T, schema string, datum interface{}, encoded 
 	if err != nil {
 		t.Fatalf("schema: %s; %s", schema, err)
 	}
-
+	toNativeAndCompare(t, schema, datum, encoded, codec)
+}
+func testJSONDecodePass(t *testing.T, schema string, datum interface{}, encoded []byte) {
+	t.Helper()
+	codec, err := NewCodecFrom(schema, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceJSON,
+	})
+	if err != nil {
+		t.Fatalf("schema: %s; %s", schema, err)
+	}
+	toNativeAndCompare(t, schema, datum, encoded, codec)
+}
+func toNativeAndCompare(t *testing.T, schema string, datum interface{}, encoded []byte, codec *Codec) {
+	t.Helper()
 	decoded, remaining, err := codec.NativeFromTextual(encoded)
 	if err != nil {
 		t.Fatalf("schema: %s; %s", schema, err)

--- a/union.go
+++ b/union.go
@@ -11,9 +11,20 @@ package goavro
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 )
+
+// codecInfo is a set of quick lookups it holds all the lookup info for the
+// all the schemas we need to handle the list of types for this union
+type codecInfo struct {
+	allowedTypes   []string
+	codecFromIndex []*Codec
+	codecFromName  map[string]*Codec
+	indexFromName  map[string]int
+}
 
 // Union wraps a datum value in a map for encoding as a Union, as required by
 // Union encoder.
@@ -43,24 +54,23 @@ func Union(name string, datum interface{}) interface{} {
 	return map[string]interface{}{name: datum}
 }
 
-func buildCodecForTypeDescribedBySlice(st map[string]*Codec, enclosingNamespace string, schemaArray []interface{}) (*Codec, error) {
-	if len(schemaArray) == 0 {
-		return nil, errors.New("Union ought to have one or more members")
-	}
-
+// makeCodecInfo takes the schema array
+// and builds some lookup indices
+// returning a codecInfo
+func makeCodecInfo(st map[string]*Codec, enclosingNamespace string, schemaArray []interface{}, cb *codecBuilder) (codecInfo, error) {
 	allowedTypes := make([]string, len(schemaArray)) // used for error reporting when encoder receives invalid datum type
 	codecFromIndex := make([]*Codec, len(schemaArray))
 	codecFromName := make(map[string]*Codec, len(schemaArray))
 	indexFromName := make(map[string]int, len(schemaArray))
 
 	for i, unionMemberSchema := range schemaArray {
-		unionMemberCodec, err := buildCodec(st, enclosingNamespace, unionMemberSchema)
+		unionMemberCodec, err := buildCodec(st, enclosingNamespace, unionMemberSchema, cb)
 		if err != nil {
-			return nil, fmt.Errorf("Union item %d ought to be valid Avro type: %s", i+1, err)
+			return codecInfo{}, fmt.Errorf("Union item %d ought to be valid Avro type: %s", i+1, err)
 		}
 		fullName := unionMemberCodec.typeName.fullName
 		if _, ok := indexFromName[fullName]; ok {
-			return nil, fmt.Errorf("Union item %d ought to be unique type: %s", i+1, unionMemberCodec.typeName)
+			return codecInfo{}, fmt.Errorf("Union item %d ought to be unique type: %s", i+1, unionMemberCodec.typeName)
 		}
 		allowedTypes[i] = fullName
 		codecFromIndex[i] = unionMemberCodec
@@ -68,112 +78,286 @@ func buildCodecForTypeDescribedBySlice(st map[string]*Codec, enclosingNamespace 
 		indexFromName[fullName] = i
 	}
 
-	return &Codec{
+	return codecInfo{
+		allowedTypes:   allowedTypes,
+		codecFromIndex: codecFromIndex,
+		codecFromName:  codecFromName,
+		indexFromName:  indexFromName,
+	}, nil
+
+}
+
+func nativeFromBinary(cr *codecInfo) func(buf []byte) (interface{}, []byte, error) {
+
+	return func(buf []byte) (interface{}, []byte, error) {
+		var decoded interface{}
+		var err error
+
+		decoded, buf, err = longNativeFromBinary(buf)
+		if err != nil {
+			return nil, nil, err
+		}
+		index := decoded.(int64) // longDecoder always returns int64, so elide error checking
+		if index < 0 || index >= int64(len(cr.codecFromIndex)) {
+			return nil, nil, fmt.Errorf("cannot decode binary union: index ought to be between 0 and %d; read index: %d", len(cr.codecFromIndex)-1, index)
+		}
+		c := cr.codecFromIndex[index]
+		decoded, buf, err = c.nativeFromBinary(buf)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot decode binary union item %d: %s", index+1, err)
+		}
+		if decoded == nil {
+			// do not wrap a nil value in a map
+			return nil, buf, nil
+		}
+		// Non-nil values are wrapped in a map with single key set to type name of value
+		return Union(cr.allowedTypes[index], decoded), buf, nil
+	}
+}
+func binaryFromNative(cr *codecInfo) func(buf []byte, datum interface{}) ([]byte, error) {
+	return func(buf []byte, datum interface{}) ([]byte, error) {
+		switch v := datum.(type) {
+		case nil:
+			index, ok := cr.indexFromName["null"]
+			if !ok {
+				return nil, fmt.Errorf("cannot encode binary union: no member schema types support datum: allowed types: %v; received: %T", cr.allowedTypes, datum)
+			}
+			return longBinaryFromNative(buf, index)
+		case map[string]interface{}:
+			if len(v) != 1 {
+				return nil, fmt.Errorf("cannot encode binary union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", cr.allowedTypes, datum)
+			}
+			// will execute exactly once
+			for key, value := range v {
+				index, ok := cr.indexFromName[key]
+				if !ok {
+					return nil, fmt.Errorf("cannot encode binary union: no member schema types support datum: allowed types: %v; received: %T", cr.allowedTypes, datum)
+				}
+				c := cr.codecFromIndex[index]
+				buf, _ = longBinaryFromNative(buf, index)
+				return c.binaryFromNative(buf, value)
+			}
+		}
+		return nil, fmt.Errorf("cannot encode binary union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", cr.allowedTypes, datum)
+	}
+}
+func nativeFromTextual(cr *codecInfo) func(buf []byte) (interface{}, []byte, error) {
+	return func(buf []byte) (interface{}, []byte, error) {
+		if len(buf) >= 4 && bytes.Equal(buf[:4], []byte("null")) {
+			if _, ok := cr.indexFromName["null"]; ok {
+				return nil, buf[4:], nil
+			}
+		}
+
+		var datum interface{}
+		var err error
+		datum, buf, err = genericMapTextDecoder(buf, nil, cr.codecFromName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot decode textual union: %s", err)
+		}
+
+		return datum, buf, nil
+	}
+}
+func textualFromNative(cr *codecInfo) func(buf []byte, datum interface{}) ([]byte, error) {
+	return func(buf []byte, datum interface{}) ([]byte, error) {
+		switch v := datum.(type) {
+		case nil:
+			_, ok := cr.indexFromName["null"]
+			if !ok {
+				return nil, fmt.Errorf("cannot encode textual union: no member schema types support datum: allowed types: %v; received: %T", cr.allowedTypes, datum)
+			}
+			return append(buf, "null"...), nil
+		case map[string]interface{}:
+			if len(v) != 1 {
+				return nil, fmt.Errorf("cannot encode textual union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", cr.allowedTypes, datum)
+			}
+			// will execute exactly once
+			for key, value := range v {
+				index, ok := cr.indexFromName[key]
+				if !ok {
+					return nil, fmt.Errorf("cannot encode textual union: no member schema types support datum: allowed types: %v; received: %T", cr.allowedTypes, datum)
+				}
+				buf = append(buf, '{')
+				var err error
+				buf, err = stringTextualFromNative(buf, key)
+				if err != nil {
+					return nil, fmt.Errorf("cannot encode textual union: %s", err)
+				}
+				buf = append(buf, ':')
+				c := cr.codecFromIndex[index]
+				buf, err = c.textualFromNative(buf, value)
+				if err != nil {
+					return nil, fmt.Errorf("cannot encode textual union: %s", err)
+				}
+				return append(buf, '}'), nil
+			}
+		}
+		return nil, fmt.Errorf("cannot encode textual union: non-nil values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", cr.allowedTypes, datum)
+	}
+}
+func buildCodecForTypeDescribedBySlice(st map[string]*Codec, enclosingNamespace string, schemaArray []interface{}, cb *codecBuilder) (*Codec, error) {
+	if len(schemaArray) == 0 {
+		return nil, errors.New("Union ought to have one or more members")
+	}
+
+	cr, err := makeCodecInfo(st, enclosingNamespace, schemaArray, cb)
+	if err != nil {
+		return nil, err
+	}
+
+	rv := &Codec{
 		// NOTE: To support record field default values, union schema set to the
 		// type name of first member
 		// TODO: add/change to schemaCanonical below
-		schemaOriginal: codecFromIndex[0].typeName.fullName,
+		schemaOriginal: cr.codecFromIndex[0].typeName.fullName,
 
-		typeName: &name{"union", nullNamespace},
-		nativeFromBinary: func(buf []byte) (interface{}, []byte, error) {
-			var decoded interface{}
-			var err error
+		typeName:          &name{"union", nullNamespace},
+		nativeFromBinary:  nativeFromBinary(&cr),
+		binaryFromNative:  binaryFromNative(&cr),
+		nativeFromTextual: nativeFromTextual(&cr),
+		textualFromNative: textualFromNative(&cr),
+	}
+	return rv, nil
+}
 
-			decoded, buf, err = longNativeFromBinary(buf)
-			if err != nil {
-				return nil, nil, err
-			}
-			index := decoded.(int64) // longDecoder always returns int64, so elide error checking
-			if index < 0 || index >= int64(len(codecFromIndex)) {
-				return nil, nil, fmt.Errorf("cannot decode binary union: index ought to be between 0 and %d; read index: %d", len(codecFromIndex)-1, index)
-			}
-			c := codecFromIndex[index]
-			decoded, buf, err = c.nativeFromBinary(buf)
-			if err != nil {
-				return nil, nil, fmt.Errorf("cannot decode binary union item %d: %s", index+1, err)
-			}
-			if decoded == nil {
-				// do not wrap a nil value in a map
-				return nil, buf, nil
-			}
-			// Non-nil values are wrapped in a map with single key set to type name of value
-			return Union(allowedTypes[index], decoded), buf, nil
-		},
-		binaryFromNative: func(buf []byte, datum interface{}) ([]byte, error) {
-			switch v := datum.(type) {
-			case nil:
-				index, ok := indexFromName["null"]
-				if !ok {
-					return nil, fmt.Errorf("cannot encode binary union: no member schema types support datum: allowed types: %v; received: %T", allowedTypes, datum)
-				}
-				return longBinaryFromNative(buf, index)
-			case map[string]interface{}:
-				if len(v) != 1 {
-					return nil, fmt.Errorf("cannot encode binary union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", allowedTypes, datum)
-				}
-				// will execute exactly once
-				for key, value := range v {
-					index, ok := indexFromName[key]
-					if !ok {
-						return nil, fmt.Errorf("cannot encode binary union: no member schema types support datum: allowed types: %v; received: %T", allowedTypes, datum)
-					}
-					c := codecFromIndex[index]
-					buf, _ = longBinaryFromNative(buf, index)
-					return c.binaryFromNative(buf, value)
-				}
-			}
-			return nil, fmt.Errorf("cannot encode binary union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", allowedTypes, datum)
-		},
-		nativeFromTextual: func(buf []byte) (interface{}, []byte, error) {
+// Standard JSON
+//
+// The default avro library supports a json that would result from your data into json
+// instead of serializing it into binary
+//
+// JSON in the wild differs from that in one critical way - unions
+// the avro spec requires unions to have their type indicated
+// which means every value that is of a union type
+// is actually sent as a small map {"string", "some string"}
+// instead of simply as the value itself, which is the way of wild JSON
+// https://avro.apache.org/docs/current/spec.html#json_encoding
+//
+// In order to use this to avro encode standard json the unions have to be rewritten
+// so the can encode into unions as expected by the avro schema
+//
+// so the technique is to read in the json in the usual way
+// when a union type is found, read the next json object
+// try to figure out if it fits into any of the types
+// that are specified for the union per the supplied schema
+// if so, then wrap the value into a map and return the expected Union
+//
+// the json is morphed on the read side
+// and then it will remain avro-json object
+// avro data is not serialized back into standard json
+// the data goes to avro-json and stays that way
+func buildCodecForTypeDescribedBySliceJSON(st map[string]*Codec, enclosingNamespace string, schemaArray []interface{}, cb *codecBuilder) (*Codec, error) {
+	if len(schemaArray) == 0 {
+		return nil, errors.New("Union ought to have one or more members")
+	}
+
+	cr, err := makeCodecInfo(st, enclosingNamespace, schemaArray, cb)
+	if err != nil {
+		return nil, err
+	}
+
+	rv := &Codec{
+		// NOTE: To support record field default values, union schema set to the
+		// type name of first member
+		// TODO: add/change to schemaCanonical below
+		schemaOriginal: cr.codecFromIndex[0].typeName.fullName,
+
+		typeName:          &name{"union", nullNamespace},
+		nativeFromBinary:  nativeFromBinary(&cr),
+		binaryFromNative:  binaryFromNative(&cr),
+		nativeFromTextual: nativeAvroFromTextualJson(&cr),
+		textualFromNative: textualFromNative(&cr),
+	}
+	return rv, nil
+}
+
+func checkAll(allowedTypes []string, cr *codecInfo, buf []byte) (interface{}, []byte, error) {
+	for _, name := range cr.allowedTypes {
+		if name == "null" {
+			// skip null since we know we already got type float64
+			continue
+		}
+		theCodec, ok := cr.codecFromName[name]
+		if !ok {
+			continue
+		}
+		rv, rb, err := theCodec.NativeFromTextual(buf)
+		if err != nil {
+			continue
+		}
+		return map[string]interface{}{name: rv}, rb, nil
+	}
+	return nil, buf, fmt.Errorf("could not decode any json data in input %v", string(buf))
+}
+func nativeAvroFromTextualJson(cr *codecInfo) func(buf []byte) (interface{}, []byte, error) {
+	return func(buf []byte) (interface{}, []byte, error) {
+
+		reader := bytes.NewReader(buf)
+		dec := json.NewDecoder(reader)
+		var m interface{}
+
+		// i should be able to grab the next json "value" with decoder.Decode()
+		// https://pkg.go.dev/encoding/json#Decoder.Decode
+		// that dec.More() loop will give the next
+		// whatever then dec.Decode(&m)
+		// if m is interface{}
+		// it goes one legit json object at a time like this
+		// json.Delim: [
+		// Q:map[string]interface {}: map[Name:Ed Text:Knock knock.]
+		// Q:map[string]interface {}: map[Name:Sam Text:Who's there?]
+		// Q:map[string]interface {}: map[Name:Ed Text:Go fmt.]
+		// Q:map[string]interface {}: map[Name:Sam Text:Go fmt who?]
+		// Q:map[string]interface {}: map[Name:Ed Text:Go fmt yourself!]
+		// string: eewew
+		// bottom:json.Delim: ]
+		//
+		// so right here, grab whatever this object is
+		// grab the object specified as the value
+		// and try to figure out what it is and handle it
+		err := dec.Decode(&m)
+		if err != nil {
+			return nil, buf, err
+		}
+
+		allowedTypes := cr.allowedTypes
+
+		switch m.(type) {
+		case nil:
 			if len(buf) >= 4 && bytes.Equal(buf[:4], []byte("null")) {
-				if _, ok := indexFromName["null"]; ok {
+				if _, ok := cr.codecFromName["null"]; ok {
 					return nil, buf[4:], nil
 				}
 			}
+		case float64:
+			// dec.Decode turns them all into float64
+			// avro spec knows about int, long (variable length zig-zag)
+			// and then float and double (32 bits, 64 bits)
+			// https://avro.apache.org/docs/current/spec.html#binary_encode_primitive
+			//
 
-			var datum interface{}
-			var err error
-			datum, buf, err = genericMapTextDecoder(buf, nil, codecFromName)
-			if err != nil {
-				return nil, nil, fmt.Errorf("cannot decode textual union: %s", err)
-			}
+			// double
+			// doubleNativeFromTextual
+			// float
+			// floatNativeFromTextual
+			// long
+			// longNativeFromTextual
+			// int
+			// intNativeFromTextual
 
-			return datum, buf, nil
-		},
-		textualFromNative: func(buf []byte, datum interface{}) ([]byte, error) {
-			switch v := datum.(type) {
-			case nil:
-				_, ok := indexFromName["null"]
-				if !ok {
-					return nil, fmt.Errorf("cannot encode textual union: no member schema types support datum: allowed types: %v; received: %T", allowedTypes, datum)
-				}
-				return append(buf, "null"...), nil
-			case map[string]interface{}:
-				if len(v) != 1 {
-					return nil, fmt.Errorf("cannot encode textual union: non-nil Union values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", allowedTypes, datum)
-				}
-				// will execute exactly once
-				for key, value := range v {
-					index, ok := indexFromName[key]
-					if !ok {
-						return nil, fmt.Errorf("cannot encode textual union: no member schema types support datum: allowed types: %v; received: %T", allowedTypes, datum)
-					}
-					buf = append(buf, '{')
-					var err error
-					buf, err = stringTextualFromNative(buf, key)
-					if err != nil {
-						return nil, fmt.Errorf("cannot encode textual union: %s", err)
-					}
-					buf = append(buf, ':')
-					c := codecFromIndex[index]
-					buf, err = c.textualFromNative(buf, value)
-					if err != nil {
-						return nil, fmt.Errorf("cannot encode textual union: %s", err)
-					}
-					return append(buf, '}'), nil
-				}
-			}
-			return nil, fmt.Errorf("cannot encode textual union: non-nil values ought to be specified with Go map[string]interface{}, with single key equal to type name, and value equal to datum value: %v; received: %T", allowedTypes, datum)
-		},
-	}, nil
+			// sorted so it would be
+			// double, float, int, long
+			// that makes the priorities right by chance
+			sort.Strings(cr.allowedTypes)
+
+		case map[string]interface{}:
+
+			// try to decode it as a map
+			// because a map should fail faster than a record
+			// if that fails assume record and return it
+			sort.Strings(cr.allowedTypes)
+		}
+
+		return checkAll(allowedTypes, cr, buf)
+
+	}
 }


### PR DESCRIPTION
## Description

Thie PR makes it so I can push **regular internet json** into goavro and get it to be avro encoded.  This makes it possible to **embed this avro library** into more recent general-purpose tools out there, particularly those in the **Kubernetes** world, where a lot of data is exposed via json.  Otherwise, none of that json is fit for this library.  This patch is currently wired into `kubernetes-events-exporter` and is handling very complicated avro schemas and high volume.

* increases the library's compatibility with the larger tooling ecosystem
* already in heavy use, integrated into existing kubernetes tooling
* includes test cases
* preserves existing functionality intact

The new functionality is added in a way that preserves the existing functionality.  This code introduces a new entry point that uses a slightly different path to handle wild json:

`func NewCodecForStandardJSON(schemaSpecification string) (*Codec, error)`

Test cases are included, and the code is already in use and working excellently.

## Details that you probably already know:

The default avro library supports a json that would result from
serializing into json with the avro library itself.

JSON in the wild differs from that in one critical way - unions.
The avro spec requires unions to have their type indicated which
means every value that is of a union type is actually sent as a
small map `{"string", "some string"}`, instead of simply as the value
itself - which is the way of wild JSON. 

### In the wild

In the wild I can find examples like this test case:

```
	testJSONDecodePass(t, `["null","long","int"]`, Union("int", 3), []byte(`3`))
```

### In avro-json

This library will not accept that JSON into a strict avro union, unless
it is delivered something like this test case shows:

```
	testTextCodecPass(t, `["null","int"]`, Union("int", 3), []byte(`{"int":3}`))

```

https://avro.apache.org/docs/current/spec.html#json_encoding

## Solution

In order to use goavro to encode standard json, the **incoming unions have
to be rewritten** so the can encode into unions as expected by the
avro schema.

## Technique

The technique is to read in the json in the usual way, and when a union
type is found, read the next json object try to figure out if it
fits into any of the types that are specified for the union per the
supplied schema, and if so, **wrap the value into a map and return
the expected Union**

* the json is morphed on the read side
* and then it will remain avro-json object
* avro data is not serialized back into standard json
* the data becomes avro-json and stays that way
