### PR TITLE
fix regression from #211 permitting dash in a name

### DIFF
--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -181,7 +181,7 @@ func TestValidatedStringLogicalTypeInRecordEncode(t *testing.T) {
 				"doc": "Phone number inside the national network. Length between 4-14",
 				"type": {
 					  "type": "string",
-					  "logicalType": "validated-string",
+					  "logicalType": "validatedString",
 					  "pattern": "^[\\d]{4,14}$"
 				}
 			}

--- a/name.go
+++ b/name.go
@@ -30,7 +30,7 @@ func (e ErrInvalidName) Error() string {
 // NOTE: This function designed to work with name components, after they have
 // been split on the period rune.
 func isRuneInvalidForFirstCharacter(r rune) bool {
-	return (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && r != '_' && r != '-'
+	return (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && r != '_'
 }
 
 func isRuneInvalidForOtherCharacters(r rune) bool {


### PR DESCRIPTION
PR #211 changed the name validation to permit dashes which broke an existing test case.  This PR removes that change, and fixes a logical-type test case that expected dashes to be permissible.