### PR TITLE
Allow decimal logical type of precision 1

### DIFF
--- a/logical_type.go
+++ b/logical_type.go
@@ -237,14 +237,14 @@ func precisionAndScaleFromSchemaMap(schemaMap map[string]interface{}) (int, int,
 		return 0, 0, fmt.Errorf("cannot create decimal logical type with wrong precision type; expected: float64; received: %T", p1)
 	}
 	p3 := int(p2)
-	if p3 <= 1 {
+	if p3 < 1 {
 		return 0, 0, fmt.Errorf("cannot create decimal logical type when precision is less than one: %d", p3)
 	}
 	var s3 int // scale defaults to 0 if not set
 	if s1, ok := schemaMap["scale"]; ok {
 		s2, ok := s1.(float64)
 		if !ok {
-			return 0, 0, fmt.Errorf("cannot create decimal logical type with wrong precision type; expected: float64; received: %T", p1)
+			return 0, 0, fmt.Errorf("cannot create decimal logical type with wrong scale type; expected: float64; received: %T", s1)
 		}
 		s3 = int(s2)
 		if s3 < 0 {


### PR DESCRIPTION
Fix scale type error message

closes #188
replaces / closes https://github.com/linkedin/goavro/pull/196

Co-Authored-By: Henry Megarry <24701548+henry-megarry@users.noreply.github.com> @henry-megarry


Simply rebasing & expanding on @henry-megarry's contribution in #196 with the hope that including some test coverage would allow for an easier acceptance by code-owner @xmcqueen 

Let me know of any concerns!