### PR TITLE
Fix bug in caching of "bytes.decimal" codec to include "precision.scale"

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -566,11 +566,26 @@ func buildCodecForTypeDescribedByString(st map[string]*Codec, enclosingNamespace
 		isLogicalType = true
 		searchType = fmt.Sprintf("%s.%s", typeName, lt)
 	}
+
 	// NOTE: When codec already exists, return it. This includes both primitive and
 	// logicalType codecs added in NewCodec, and user-defined types, added while
 	// building the codec.
 	if cd, ok := st[searchType]; ok {
-		return cd, nil
+
+		// For "bytes.decimal" types verify that the scale and precision in this schema map match a cached codec before
+		// using the cached codec in favor of creating a new codec.
+		if searchType == "bytes.decimal" {
+
+			// Search the cached codecs for a "bytes.decimal" codec  with a "precision" and "scale" specified in the key,
+			// only if that matches return the cached codec. Otherwise, create a new codec for this "bytes.decimal".
+			decimalSearchType := fmt.Sprintf("bytes.decimal.%d.%d", int(schemaMap["precision"].(float64)), int(schemaMap["scale"].(float64)))
+			if cd2, ok := st[decimalSearchType]; ok {
+				return cd2, nil
+			}
+
+		} else {
+			return cd, nil
+		}
 	}
 
 	// Avro specification allows abbreviation of type name inside a namespace.

--- a/logical_type.go
+++ b/logical_type.go
@@ -271,6 +271,11 @@ func makeDecimalBytesCodec(st map[string]*Codec, enclosingNamespace string, sche
 	if err != nil {
 		return nil, fmt.Errorf("Bytes ought to have valid name: %s", err)
 	}
+
+	// Add an additional cached codec for this "bytes.decimal" keyed also by "precision" and "scale"
+	decimalSearchType := fmt.Sprintf("bytes.decimal.%d.%d", precision, scale)
+	st[decimalSearchType] = c
+
 	c.binaryFromNative = decimalBytesFromNative(bytesBinaryFromNative, toSignedBytes, precision, scale)
 	c.textualFromNative = decimalBytesFromNative(bytesTextualFromNative, toSignedBytes, precision, scale)
 	c.nativeFromBinary = nativeFromDecimalBytes(bytesNativeFromBinary, precision, scale)


### PR DESCRIPTION
replaces / closes https://github.com/linkedin/goavro/pull/195

Co-Authored-By: Mark Christiansen <51971073+mark-christiansen@users.noreply.github.com>

Simply rebasing & expanding on @mark-christiansen's contribution in #195 with the hope that including some test coverage would allow for an easier acceptance by code-owner @xmcqueen

Let me know of any concerns!