### PR TITLE
Fix examples' imports to use goavro/v2

### DIFF
--- a/examples/165/main.go
+++ b/examples/165/main.go
@@ -37,7 +37,7 @@ package main
 import (
 	"os"
 
-	"github.com/linkedin/goavro"
+	"github.com/linkedin/goavro/v2"
 )
 
 const loginEventAvroSchema = `{"type": "record", "name": "LoginEvent", "fields": [{"name": "Username", "type": "string"}]}`

--- a/examples/soe/main.go
+++ b/examples/soe/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/linkedin/goavro"
+	"github.com/linkedin/goavro/v2"
 )
 
 func main() {


### PR DESCRIPTION
Builds & tests were previously broken due to these incorrect imports. Now work with no change to `go.mod`:
`go build ./... && go test ./...`