### PR TITLE
Fix narrowing conversion bug in timeMicrosFromNative

### DIFF
--- a/logical_type.go
+++ b/logical_type.go
@@ -127,7 +127,7 @@ func timeMicrosFromNative(fn fromNativeFn) fromNativeFn {
 			return fn(b, val)
 
 		case time.Duration:
-			duration := int32(val.Nanoseconds() / int64(time.Microsecond))
+			duration := val.Nanoseconds() / int64(time.Microsecond)
 			return fn(b, duration)
 
 		default:

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -85,14 +85,12 @@ func TestTimeMicrosLogicalTypeEncode(t *testing.T) {
 	schema := `{"type": "long", "logicalType": "time-micros"}`
 	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
 	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary time-micros, expected time.Duration")
-	t.Skip("this test is broken")
 	testBinaryCodecPass(t, schema, 66904022566*time.Microsecond, []byte("\xcc\xf8\xd2\xbc\xf2\x03"))
 }
 
 func TestTimeMicrosLogicalTypeUnionEncode(t *testing.T) {
 	schema := `{"type": ["null", {"type": "long", "logicalType": "time-micros"}]}`
 	testBinaryEncodeFail(t, schema, Union("string", "test"), "cannot encode binary union: no member schema types support datum: allowed types: [null long.time-micros]")
-	t.Skip("this test is broken")
 	testBinaryCodecPass(t, schema, Union("long.time-micros", 66904022566*time.Microsecond), []byte("\x02\xcc\xf8\xd2\xbc\xf2\x03"))
 }
 func TestDateLogicalTypeEncode(t *testing.T) {


### PR DESCRIPTION
Looks like this issue comes from a regression introduced in #213.

Fixes #242.

@kjschubert would you mind having a look at this to see if it makes sense to you? I'm not super-experienced with these logical types in AVRO and I see that these two tests were disabled after #213 went in, but they're working again after this fix.