### PR TITLE
Enable linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,15 @@
+name: golangci-lint
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.45.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: test
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v3
+      - run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  timeout: 30s
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  depguard:
+    include-go-root: true
+    packages:
+      - "io/ioutil"
+
+linters:
+  enable:
+    # Enable some extra linters
+    - gofmt
+    - goimports
+    - gocritic
+    - revive
+    # stylecheck warns about errors starting with a capital letter, which should be fixed in the next major release
+    # - stylecheck
+    - unconvert
+    - durationcheck
+    - wastedassign
+    - depguard
+    - bodyclose
+    - gosec
+    - misspell
+    - prealloc

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -10,12 +10,12 @@
 package goavro
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func BenchmarkNewCodecUsingV2(b *testing.B) {
-	schema, err := ioutil.ReadFile("fixtures/quickstop.avsc")
+	schema, err := os.ReadFile("fixtures/quickstop.avsc")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func BenchmarkNewCodecUsingV2(b *testing.B) {
 }
 
 func BenchmarkNativeFromAvroUsingV2(b *testing.B) {
-	avroBlob, err := ioutil.ReadFile("fixtures/quickstop-null.avro")
+	avroBlob, err := os.ReadFile("fixtures/quickstop-null.avro")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func BenchmarkNativeFromAvroUsingV2(b *testing.B) {
 }
 
 func BenchmarkBinaryFromNativeUsingV2(b *testing.B) {
-	avroBlob, err := ioutil.ReadFile("fixtures/quickstop-null.avro")
+	avroBlob, err := os.ReadFile("fixtures/quickstop-null.avro")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func BenchmarkBinaryFromNativeUsingV2(b *testing.B) {
 }
 
 func BenchmarkNativeFromBinaryUsingV2(b *testing.B) {
-	avroBlob, err := ioutil.ReadFile("fixtures/quickstop-null.avro")
+	avroBlob, err := os.ReadFile("fixtures/quickstop-null.avro")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func BenchmarkNativeFromBinaryUsingV2(b *testing.B) {
 }
 
 func BenchmarkTextualFromNativeUsingV2(b *testing.B) {
-	avroBlob, err := ioutil.ReadFile("fixtures/quickstop-null.avro")
+	avroBlob, err := os.ReadFile("fixtures/quickstop-null.avro")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func BenchmarkTextualFromNativeUsingV2(b *testing.B) {
 }
 
 func BenchmarkNativeFromTextualUsingV2(b *testing.B) {
-	avroBlob, err := ioutil.ReadFile("fixtures/quickstop-null.avro")
+	avroBlob, err := os.ReadFile("fixtures/quickstop-null.avro")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/canonical.go
+++ b/canonical.go
@@ -16,10 +16,6 @@ import (
 	"strings"
 )
 
-// pcfProcessor is a function type that given a parsed JSON object, returns its
-// Parsing Canonical Form according to the Avro specification.
-type pcfProcessor func(s interface{}) (string, error)
-
 // parsingCanonialForm returns the "Parsing Canonical Form" (pcf) for a parsed
 // JSON structure of a valid Avro schema, or an error describing the schema
 // error.

--- a/codec.go
+++ b/codec.go
@@ -511,7 +511,7 @@ func (c *Codec) CanonicalSchema() string {
 // canonical schema.  This method returns the signed 64-bit cast of the unsigned
 // 64-bit schema Rabin fingerprint.
 //
-// DEPRECATED: This method has been replaced by the Rabin structure Codec field
+// Deprecated: This method has been replaced by the Rabin structure Codec field
 // and is provided for backward compatibility only.
 func (c *Codec) SchemaCRC64Avro() int64 {
 	return int64(c.Rabin)

--- a/codec_test.go
+++ b/codec_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 )
 
-func ExampleCodecCanonicalSchema() {
+func ExampleCodec_CanonicalSchema() {
 	schema := `{"type":"map","values":{"type":"enum","name":"foo","symbols":["alpha","bravo"]}}`
 	codec, err := NewCodec(schema)
 	if err != nil {
@@ -245,7 +245,7 @@ func TestSingleObjectEncoding(t *testing.T) {
 	})
 }
 
-func ExampleSingleItemEncoding() {
+func ExampleCodec_SingleFromNative() {
 	codec, err := NewCodec(`"int"`)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
@@ -262,7 +262,7 @@ func ExampleSingleItemEncoding() {
 	// Output: [195 1 143 92 57 63 26 213 117 114 6]
 }
 
-func ExampleSingleItemDecoding() {
+func ExampleCodec_NativeFromBinary_singleItemDecoding() {
 	codec1, err := NewCodec(`"int"`)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/codec_test.go
+++ b/codec_test.go
@@ -205,7 +205,7 @@ func TestSingleObjectEncoding(t *testing.T) {
 		codec, err := NewCodec(`
 {
   "type": "record",
-  "name": "LongList",                  
+  "name": "LongList",
   "fields" : [
     {"name": "next", "type": ["null", "LongList"], "default": null}
   ]

--- a/codec_test.go
+++ b/codec_test.go
@@ -182,10 +182,7 @@ func TestSingleObjectEncoding(t *testing.T) {
 		})
 
 		t.Run("decoding", func(t *testing.T) {
-			const original = ""
-			buf := []byte(original)
-
-			buf, err = codec.SingleFromNative(nil, 3)
+			buf, err := codec.SingleFromNative(nil, 3)
 			ensureError(t, err)
 
 			buf = append(buf, "\xDE\xAD"...) // append some junk

--- a/debug_development.go
+++ b/debug_development.go
@@ -1,4 +1,4 @@
-// +build goavro_debug
+//go:build goavro_debug
 
 package goavro
 

--- a/debug_release.go
+++ b/debug_release.go
@@ -1,4 +1,4 @@
-// +build !goavro_debug
+//go:build !goavro_debug
 
 package goavro
 

--- a/ensure_test.go
+++ b/ensure_test.go
@@ -3,20 +3,9 @@ package goavro
 // NOTE: This file was copied from https://github.com/karrick/gorill
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
-
-func ensureBuffer(tb testing.TB, buf []byte, n int, want string) {
-	tb.Helper()
-	if got, want := n, len(want); got != want {
-		tb.Fatalf("GOT: %v; WANT: %v", got, want)
-	}
-	if got, want := string(buf[:n]), want; got != want {
-		tb.Errorf("GOT: %v; WANT: %v", got, want)
-	}
-}
 
 func ensureError(tb testing.TB, err error, contains ...string) {
 	tb.Helper()
@@ -39,21 +28,6 @@ func ensureError(tb testing.TB, err error, contains ...string) {
 	}
 }
 
-func ensurePanic(tb testing.TB, want string, callback func()) {
-	tb.Helper()
-	defer func() {
-		r := recover()
-		if r == nil {
-			tb.Fatalf("GOT: %v; WANT: %v", r, want)
-			return
-		}
-		if got := fmt.Sprintf("%v", r); got != want {
-			tb.Fatalf("GOT: %v; WANT: %v", got, want)
-		}
-	}()
-	callback()
-}
-
 // ensureNoPanic prettifies the output so one knows which test case caused a
 // panic.
 func ensureNoPanic(tb testing.TB, label string, callback func()) {
@@ -64,26 +38,4 @@ func ensureNoPanic(tb testing.TB, label string, callback func()) {
 		}
 	}()
 	callback()
-}
-
-func ensureStringSlicesMatch(tb testing.TB, actual, expected []string) {
-	tb.Helper()
-	if got, want := len(actual), len(expected); got != want {
-		tb.Errorf("GOT: %v; WANT: %v", got, want)
-	}
-	la := len(actual)
-	le := len(expected)
-	for i := 0; i < la || i < le; i++ {
-		if i < la {
-			if i < le {
-				if got, want := actual[i], expected[i]; got != want {
-					tb.Errorf("GOT: %q; WANT: %q", got, want)
-				}
-			} else {
-				tb.Errorf("GOT: %q (extra)", actual[i])
-			}
-		} else if i < le {
-			tb.Errorf("WANT: %q (missing)", expected[i])
-		}
-	}
 }

--- a/ensure_test.go
+++ b/ensure_test.go
@@ -24,7 +24,11 @@ func ensureError(tb testing.TB, err error, contains ...string) {
 		if err != nil {
 			tb.Fatalf("GOT: %v; WANT: %v", err, contains)
 		}
-	} else if err == nil {
+
+		return
+	}
+
+	if err == nil {
 		tb.Errorf("GOT: %v; WANT: %v", err, contains)
 	} else {
 		for _, stub := range contains {

--- a/enum_test.go
+++ b/enum_test.go
@@ -119,9 +119,9 @@ func ExampleCodec_NativeFromTextual_checkSolutionGH233() {
 	`
 	codec, _ := NewCodec(avroSchema)
 
-	const avroJson = `{"event":{"com.foo.bar.FooBarEvent":"CREATED"}}`
+	const avroJSON = `{"event":{"com.foo.bar.FooBarEvent":"CREATED"}}`
 
-	native, _, err := codec.NativeFromTextual([]byte(avroJson))
+	native, _, err := codec.NativeFromTextual([]byte(avroJSON))
 	if err != nil {
 		panic(err)
 	}

--- a/enum_test.go
+++ b/enum_test.go
@@ -96,7 +96,7 @@ func TestGH233(t *testing.T) {
 
 }
 
-func ExampleCheckSolutionGH233() {
+func ExampleCodec_NativeFromTextual_checkSolutionGH233() {
 	const avroSchema = `
 	{
 		"type": "record",

--- a/floatingPoint.go
+++ b/floatingPoint.go
@@ -99,7 +99,7 @@ func floatBinaryFromNative(buf []byte, datum interface{}) ([]byte, error) {
 	}
 	// return floatingBinaryEncoder(buf, uint64(math.Float32bits(value)), floatEncodedLength)
 	buf = append(buf, 0, 0, 0, 0)
-	binary.LittleEndian.PutUint32(buf[len(buf)-floatEncodedLength:], uint32(math.Float32bits(value)))
+	binary.LittleEndian.PutUint32(buf[len(buf)-floatEncodedLength:], math.Float32bits(value))
 	return buf, nil
 }
 

--- a/floatingPoint.go
+++ b/floatingPoint.go
@@ -161,6 +161,7 @@ func numberLength(buf []byte, floatAllowed bool) (int, error) {
 		}
 	}
 	// STATE 1: if 0, goto 2; otherwise if 1-9, goto 3; otherwise bail
+	// nolint:gocritic
 	if b = buf[index]; b == '0' {
 		if index++; index == buflen {
 			return index, nil // valid number

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -11,43 +11,7 @@ package goavro
 
 import (
 	"io"
-	"runtime"
-	"sync"
-	"testing"
 )
-
-func benchmarkLowAndHigh(b *testing.B, callback func()) {
-	b.Helper()
-	// Run test case in parallel at relative low concurrency
-	b.Run("Low", func(b *testing.B) {
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				callback()
-			}
-		})
-	})
-
-	// Run test case in parallel at relative high concurrency
-	b.Run("High", func(b *testing.B) {
-		concurrency := runtime.NumCPU() * 1000
-		wg := new(sync.WaitGroup)
-		wg.Add(concurrency)
-		b.ResetTimer()
-
-		for c := 0; c < concurrency; c++ {
-			go func() {
-				defer wg.Done()
-
-				for n := 0; n < b.N; n++ {
-					callback()
-				}
-			}()
-		}
-
-		wg.Wait()
-	})
-}
 
 // ShortWriter returns a structure that wraps an io.Writer, but returns
 // io.ErrShortWrite when the number of bytes to write exceeds a preset limit.

--- a/integer.go
+++ b/integer.go
@@ -118,7 +118,7 @@ func integerBinaryEncoder(buf []byte, encoded uint64) ([]byte, error) {
 	}
 	for encoded > 0 {
 		b := byte(encoded) & intMask
-		encoded = encoded >> 7
+		encoded >>= 7
 		if encoded != 0 {
 			b |= intFlag // set high bit; we have more bytes
 		}

--- a/logical_type.go
+++ b/logical_type.go
@@ -225,7 +225,6 @@ func timeStampMicrosFromNative(fn fromNativeFn) fromNativeFn {
 // two's complement algorithm taken from:
 // https://groups.google.com/d/msg/golang-nuts/TV4bRVrHZUw/UcQt7S4IYlcJ by rog
 /////////////////////////////////////////////////////////////////////////////////////////////
-type makeCodecFn func(st map[string]*Codec, enclosingNamespace string, schemaMap map[string]interface{}) (*Codec, error)
 
 func precisionAndScaleFromSchemaMap(schemaMap map[string]interface{}) (int, int, error) {
 	p1, ok := schemaMap["precision"]

--- a/logical_type.go
+++ b/logical_type.go
@@ -425,7 +425,7 @@ func validatedStringNativeFromTextual(fn toNativeFn, pattern string) toNativeFn 
 
 func padBytes(bytes []byte, fixedSize uint) []byte {
 	s := int(fixedSize)
-	padded := make([]byte, s, s)
+	padded := make([]byte, s)
 	if s >= len(bytes) {
 		copy(padded[s-len(bytes):], bytes)
 	}

--- a/logical_type.go
+++ b/logical_type.go
@@ -380,15 +380,11 @@ func makeValidatedStringCodec(st map[string]*Codec, enclosingNamespace string, s
 }
 
 func validatedStringBinaryFromNative(fromNativeFn fromNativeFn) fromNativeFn {
-	return func(b []byte, d interface{}) ([]byte, error) {
-		return stringBinaryFromNative(b, d)
-	}
+	return stringBinaryFromNative
 }
 
 func validatedStringTextualFromNative(fromNativeFn fromNativeFn) fromNativeFn {
-	return func(b []byte, d interface{}) ([]byte, error) {
-		return stringTextualFromNative(b, d)
-	}
+	return stringTextualFromNative
 }
 
 func validatedStringNativeFromBinary(fn toNativeFn, pattern string) toNativeFn {

--- a/map.go
+++ b/map.go
@@ -301,7 +301,7 @@ func convertMap(datum interface{}) (map[string]interface{}, error) {
 			// bail when map key type is not string
 			return nil, fmt.Errorf("cannot create map[string]interface{}: expected map[string]...; received: %T", datum)
 		}
-		mapValues[string(k)] = v.MapIndex(key).Interface()
+		mapValues[k] = v.MapIndex(key).Interface()
 	}
 	return mapValues, nil
 }

--- a/name.go
+++ b/name.go
@@ -75,6 +75,7 @@ func newName(n, ns, ens string) (*name, error) {
 		nn.namespace = n[:index]
 	} else {
 		// inputName does not contain a dot, therefore is not the full name
+		// nolint:gocritic
 		if ns != nullNamespace {
 			// if namespace provided in the schema in the same schema level, use it
 			nn.fullName = ns + "." + n

--- a/ocf.go
+++ b/ocf.go
@@ -88,6 +88,7 @@ func newOCFHeader(config OCFConfig) (*ocfHeader, error) {
 	//
 	// avro.schema
 	//
+	// nolint:gocritic
 	if config.Codec != nil {
 		header.codec = config.Codec
 	} else if config.Schema == "" {

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -59,7 +59,7 @@ func NewOCFReader(ior io.Reader) (*OCFReader, error) {
 	return &OCFReader{header: header, ior: ior}, nil
 }
 
-//MetaData returns the file metadata map found within the OCF file
+// MetaData returns the file metadata map found within the OCF file
 func (ocfr *OCFReader) MetaData() map[string][]byte {
 	return ocfr.header.metadata
 }

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 
 	"github.com/golang/snappy"
 )
@@ -192,7 +191,7 @@ func (ocfr *OCFReader) Scan() bool {
 			// NOTE: flate.NewReader wraps with io.ByteReader if argument does
 			// not implement that interface.
 			rc := flate.NewReader(bytes.NewBuffer(ocfr.block))
-			ocfr.block, ocfr.rerr = ioutil.ReadAll(rc)
+			ocfr.block, ocfr.rerr = io.ReadAll(rc)
 			if ocfr.rerr != nil {
 				_ = rc.Close()
 				return false

--- a/ocf_test.go
+++ b/ocf_test.go
@@ -11,7 +11,6 @@ package goavro
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 )
 
@@ -72,8 +71,8 @@ func testOCFRoundTripWithHeaders(t *testing.T, compressionName string, headers m
 
 	readMeta := ocfr.MetaData()
 	for k, v := range headers {
-		expected := fmt.Sprintf("%s", v)
-		actual := fmt.Sprintf("%s", readMeta[k])
+		expected := string(v)
+		actual := string(readMeta[k])
 		if actual != expected {
 			t.Errorf("GOT: %v; WANT: %v (%v)", actual, expected, k)
 		}

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -71,11 +71,10 @@ func NewOCFWriter(config OCFConfig) (*OCFWriter, error) {
 	var err error
 	ocf := &OCFWriter{iow: config.W}
 
-	switch config.W.(type) {
+	switch file := config.W.(type) {
 	case nil:
 		return nil, errors.New("cannot create OCFWriter when W is nil")
 	case *os.File:
-		file := config.W.(*os.File)
 		stat, err := file.Stat()
 		if err != nil {
 			return nil, fmt.Errorf("cannot create OCFWriter: %s", err)

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang/snappy"
@@ -140,7 +139,7 @@ func (ocfw *OCFWriter) quickScanToTail(ior io.Reader) error {
 			return fmt.Errorf("cannot read when block size exceeds MaxBlockSize: %d > %d", blockSize, MaxBlockSize)
 		}
 		// Advance reader to end of block
-		if _, err = io.CopyN(ioutil.Discard, ior, blockSize); err != nil {
+		if _, err = io.CopyN(io.Discard, ior, blockSize); err != nil {
 			return fmt.Errorf("cannot seek to next block: %s", err)
 		}
 		// Read and validate sync marker

--- a/record.go
+++ b/record.go
@@ -68,7 +68,7 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 				if !ok {
 					return nil, fmt.Errorf("Record %q field %q: default value ought to encode using field schema: %s", c.typeName, fieldName, err)
 				}
-				defaultValue = bool(v)
+				defaultValue = v
 			case "bytes":
 				v, ok := defaultValue.(string)
 				if !ok {
@@ -80,7 +80,7 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 				if !ok {
 					return nil, fmt.Errorf("Record %q field %q: default value ought to encode using field schema: %s", c.typeName, fieldName, err)
 				}
-				defaultValue = float64(v)
+				defaultValue = v
 			case "float":
 				v, ok := defaultValue.(float64)
 				if !ok {
@@ -104,7 +104,7 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 				if !ok {
 					return nil, fmt.Errorf("Record %q field %q: default value ought to encode using field schema: %s", c.typeName, fieldName, err)
 				}
-				defaultValue = string(v)
+				defaultValue = v
 			case "union":
 				// When codec is union, then default value ought to encode using
 				// first schema in union.  NOTE: To support a null default

--- a/record_test.go
+++ b/record_test.go
@@ -410,7 +410,7 @@ func TestRecordRecursiveRoundTrip(t *testing.T) {
 	codec, err := NewCodec(`
 {
   "type": "record",
-  "name": "LongList",                  
+  "name": "LongList",
   "fields" : [
     {"name": "next", "type": ["null", "LongList"], "default": null}
   ]

--- a/record_test.go
+++ b/record_test.go
@@ -445,7 +445,7 @@ func TestRecordRecursiveRoundTrip(t *testing.T) {
 	}
 }
 
-func ExampleRecordRecursiveRoundTrip() {
+func ExampleCodec_NativeFromTextual_roundTrip() {
 	codec, err := NewCodec(`
 {
   "type": "record",
@@ -492,7 +492,7 @@ func ExampleRecordRecursiveRoundTrip() {
 	// Output: {"next":{"LongList":{"next":{"LongList":{"next":null}}}}}
 }
 
-func ExampleBinaryFromNative() {
+func ExampleCodec_BinaryFromNative_avro() {
 	codec, err := NewCodec(`
 {
   "type": "record",
@@ -526,7 +526,7 @@ func ExampleBinaryFromNative() {
 	// Output: []byte{0x2, 0x2, 0x0}
 }
 
-func ExampleNativeFromBinary() {
+func ExampleCodec_NativeFromBinary_avro() {
 	codec, err := NewCodec(`
 {
   "type": "record",
@@ -552,7 +552,7 @@ func ExampleNativeFromBinary() {
 	// Output: map[next:map[LongList:map[next:map[LongList:map[next:<nil>]]]]]
 }
 
-func ExampleNativeFromTextual() {
+func ExampleCodec_NativeFromTextual_avro() {
 	codec, err := NewCodec(`
 {
   "type": "record",
@@ -578,7 +578,7 @@ func ExampleNativeFromTextual() {
 	// Output: map[next:map[LongList:map[next:map[LongList:map[next:<nil>]]]]]
 }
 
-func ExampleTextualFromNative() {
+func ExampleCodec_TextualFromNative_avro() {
 	codec, err := NewCodec(`
 {
   "type": "record",

--- a/schema_test.go
+++ b/schema_test.go
@@ -71,10 +71,10 @@ func TestSchemaFooBarSpecificRecord(t *testing.T) {
         {"name": "name", "type": "string"},
         {"name": "nicknames", "type":
             {"type": "array", "items": "string"}},
-        {"name": "relatedids", "type": 
+        {"name": "relatedids", "type":
             {"type": "array", "items": "int"}},
-        {"name": "typeEnum", "type": 
-            ["null", { 
+        {"name": "typeEnum", "type":
+            ["null", {
                     "type": "enum",
                     "name": "TypeEnum",
                     "namespace": "org.apache.avro",

--- a/union.go
+++ b/union.go
@@ -265,7 +265,7 @@ func buildCodecForTypeDescribedBySliceJSON(st map[string]*Codec, enclosingNamesp
 		typeName:          &name{"union", nullNamespace},
 		nativeFromBinary:  nativeFromBinary(&cr),
 		binaryFromNative:  binaryFromNative(&cr),
-		nativeFromTextual: nativeAvroFromTextualJson(&cr),
+		nativeFromTextual: nativeAvroFromTextualJSON(&cr),
 		textualFromNative: textualFromNative(&cr),
 	}
 	return rv, nil
@@ -289,7 +289,7 @@ func checkAll(allowedTypes []string, cr *codecInfo, buf []byte) (interface{}, []
 	}
 	return nil, buf, fmt.Errorf("could not decode any json data in input %v", string(buf))
 }
-func nativeAvroFromTextualJson(cr *codecInfo) func(buf []byte) (interface{}, []byte, error) {
+func nativeAvroFromTextualJSON(cr *codecInfo) func(buf []byte) (interface{}, []byte, error) {
 	return func(buf []byte) (interface{}, []byte, error) {
 
 		reader := bytes.NewReader(buf)

--- a/union_test.go
+++ b/union_test.go
@@ -159,7 +159,7 @@ func TestUnionText(t *testing.T) {
 	testTextCodecPass(t, `["null","int","string"]`, Union("string", "😂 "), []byte(`{"string":"\u0001\uD83D\uDE02 "}`))
 }
 
-func ExampleUnion() {
+func ExampleCodec_TextualFromNative_union() {
 	codec, err := NewCodec(`["null","string","int"]`)
 	if err != nil {
 		fmt.Println(err)
@@ -172,7 +172,7 @@ func ExampleUnion() {
 	// Output: {"string":"some string"}
 }
 
-func ExampleUnion3() {
+func ExampleCodec_TextualFromNative_union_json() {
 	// Imagine a record field with the following union type. I have seen this
 	// sort of type in many schemas. I have been told the reasoning behind it is
 	// when the writer desires to encode data to JSON that cannot be written as
@@ -221,19 +221,6 @@ func ExampleUnion3() {
 	// Output: decoded string: NaN
 }
 
-func ExampleJSONUnion() {
-	codec, err := NewCodec(`["null","string","int"]`)
-	if err != nil {
-		fmt.Println(err)
-	}
-	buf, err := codec.TextualFromNative(nil, Union("string", "some string"))
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(string(buf))
-	// Output: {"string":"some string"}
-}
-
 //
 // The following examples show the way to put a new codec into use
 // Currently the only new codec is ont that supports standard json
@@ -241,7 +228,7 @@ func ExampleJSONUnion() {
 // so standard json data needs to be guided into avro unions
 
 // show how to use the default codec via the NewCodecFrom mechanism
-func ExampleCustomCodec() {
+func ExampleCodec_TextualFromNative() {
 	codec, err := NewCodecFrom(`"string"`, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,
@@ -259,7 +246,7 @@ func ExampleCustomCodec() {
 }
 
 // Use the standard JSON codec instead
-func ExampleJSONStringToTextual() {
+func ExampleCodec_TextualFromNative_json() {
 	codec, err := NewCodecFrom(`["null","string","int"]`, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,
@@ -276,7 +263,7 @@ func ExampleJSONStringToTextual() {
 	// Output: {"string":"some string"}
 }
 
-func ExampleJSONStringToNative() {
+func ExampleCodec_NativeFromTextual_json() {
 	codec, err := NewCodecFrom(`["null","string","int"]`, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,

--- a/union_test.go
+++ b/union_test.go
@@ -285,7 +285,7 @@ func ExampleCodec_NativeFromTextual_json() {
 
 	// pull out the string to show its all good
 	_v := o["string"]
-	v, ok := _v.(string)
+	v := _v.(string)
 	fmt.Println(v)
 	// Output: some string one
 }


### PR DESCRIPTION
I thought a bit of cleanup might be handy. I can disable the `deadcode` linter if you'd rather preserve that unused code.

I also enabled the tests and linting via GitHub Actions. If you'd like the tests to be faster (it takes 2 min now), the test matrix can be slimmed down, just let me know what you'd like to have in there.