### PR TITLE
Added Two Way Handling for Standard Json

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -107,7 +107,19 @@ func NewCodecForStandardJSON(schemaSpecification string) (*Codec, error) {
 	return NewCodecFrom(schemaSpecification, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,
-		buildCodecForTypeDescribedBySliceJSON,
+		buildCodecForTypeDescribedBySliceOneWayJson,
+	})
+}
+
+func NewCodecForStandardJsonOneWay(schemaSpecification string) (*Codec, error) {
+	return NewCodecForStandardJSON(schemaSpecification)
+}
+
+func NewCodecForStandardJsonFull(schemaSpecification string) (*Codec, error) {
+	return NewCodecFrom(schemaSpecification, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceTwoWayJson,
 	})
 }
 

--- a/codec.go
+++ b/codec.go
@@ -103,6 +103,48 @@ func NewCodec(schemaSpecification string) (*Codec, error) {
 	})
 }
 
+// NewCodecForStandardJSON returns a codec that uses a special union
+// processing code that allows normal json to be ingested via an
+// avro schema, by inferring the "type" intended for union types.
+//
+// This is the one-way code to get such json into the avro system
+// and the deserialization is not supported in this codec - its
+// json into avro-json one-way and one-way only for this codec.
+//
+// The "type" inference is done by using the types specified as
+// potentially acceptable types for the union, and trying to
+// unpack the incomin json into each of the specified types for
+// the union type. See union.go +/Standard JSON/ for a general
+// description of the problem and details of the solution
+// are in union.go +/nativeAvroFromTextualJson/
+//
+// For a general description of a codex seen the comment for NewCodec
+// above.
+//
+// The following is the exact same schema used in the above
+// code for NewCodec:
+//
+//     codec, err := goavro.NewCodecForStandardJSON(`
+//         {
+//           "type": "record",
+//           "name": "LongList",
+//           "fields" : [
+//             {"name": "next", "type": ["null", "LongList"], "default": null}
+//           ]
+//         }`)
+//     if err != nil {
+//             fmt.Println(err)
+//     }
+//
+// The above will take json of this sort:
+//
+// {"next": null}
+//
+// {"next":{"next":null}}
+//
+// {"next":{"next":{"next":null}}}
+//
+// For more examples see the test cases in union_test.go
 func NewCodecForStandardJSON(schemaSpecification string) (*Codec, error) {
 	return NewCodecFrom(schemaSpecification, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
@@ -111,11 +153,44 @@ func NewCodecForStandardJSON(schemaSpecification string) (*Codec, error) {
 	})
 }
 
-func NewCodecForStandardJsonOneWay(schemaSpecification string) (*Codec, error) {
+// NewCodecForStandardJSONOneWay is an alias for NewCodecForStandardJSON
+// added to make the transition to two-way json handling more smooth
+//
+// This will unambiguously provide OneWay avro encoding for standard
+// internet json. This takes in internet json, and brings it into
+// the avro world, but the deserialization retains the unique
+// form of normal avro-friendly json where unions have their
+// types types specified in stream like this example from
+// the official docs // https://avro.apache.org/docs/1.11.1/api/c/
+//
+// `{"string": "Follow your bliss."}`
+//
+// To be clear this means the incoming json string:
+//
+// "Follow your bliss."
+//
+// would deserialize according to the avro-json expectations to:
+//
+// `{"string": "Follow your bliss."}`
+//
+// To get full two-way support see the below NewCodecForStandardJSONFull
+func NewCodecForStandardJSONOneWay(schemaSpecification string) (*Codec, error) {
 	return NewCodecForStandardJSON(schemaSpecification)
 }
 
-func NewCodecForStandardJsonFull(schemaSpecification string) (*Codec, error) {
+// NewCodecForStandardJSONFull provides full serialization/deserialization
+// for json that meets the expectations of regular internet json, viewed as
+// something distinct from avro-json which has special handling for union
+// types.  For details see the above comments.
+//
+// With this `codec` you can expect to see a json string like this:
+//
+// "Follow your bliss."
+//
+// to deserialize into the same json structure
+//
+// "Follow your bliss."
+func NewCodecForStandardJSONFull(schemaSpecification string) (*Codec, error) {
 	return NewCodecFrom(schemaSpecification, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/linkedin/goavro/v2
 
 go 1.12
 
-require github.com/golang/snappy v0.0.1
+require (
+	github.com/golang/snappy v0.0.1
+	github.com/stretchr/testify v1.7.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/text_test.go
+++ b/text_test.go
@@ -63,18 +63,41 @@ func testTextDecodePass(t *testing.T, schema string, datum interface{}, encoded 
 	}
 	toNativeAndCompare(t, schema, datum, encoded, codec)
 }
-func testJSONDecodePass(t *testing.T, schema string, datum interface{}, encoded []byte) {
+func testJsonDecodePass(t *testing.T, schema string, datum interface{}, encoded []byte) {
 	t.Helper()
 	codec, err := NewCodecFrom(schema, &codecBuilder{
 		buildCodecForTypeDescribedByMap,
 		buildCodecForTypeDescribedByString,
-		buildCodecForTypeDescribedBySliceJSON,
+		buildCodecForTypeDescribedBySliceOneWayJson,
 	})
 	if err != nil {
 		t.Fatalf("schema: %s; %s", schema, err)
 	}
 	toNativeAndCompare(t, schema, datum, encoded, codec)
 }
+func testNativeToTextualJsonPass(t *testing.T, schema string, datum interface{}, encoded []byte) {
+	t.Helper()
+	codec, err := NewCodecFrom(schema, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceTwoWayJson,
+	})
+	if err != nil {
+		t.Fatalf("schema: %s; %s", schema, err)
+	}
+	toTextualAndCompare(t, schema, datum, encoded, codec)
+}
+func toTextualAndCompare(t *testing.T, schema string, datum interface{}, encoded []byte, codec *Codec) {
+	t.Helper()
+	decoded, err := codec.TextualFromNative(nil, datum)
+	if err != nil {
+		t.Fatalf("schema: %s; %s", schema, err)
+	}
+	if !bytes.Equal(decoded, encoded) {
+		t.Errorf("GOT: %v; WANT: %v", string(decoded), string(encoded))
+	}
+}
+
 func toNativeAndCompare(t *testing.T, schema string, datum interface{}, encoded []byte, codec *Codec) {
 	t.Helper()
 	decoded, remaining, err := codec.NativeFromTextual(encoded)

--- a/union_test.go
+++ b/union_test.go
@@ -303,69 +303,52 @@ func ExampleJSONStringToNative() {
 	// Output: some string one
 }
 
-func TestUnionJson(t *testing.T) {
-	testJsonDecodePass(t, `["null","int"]`, nil, []byte("null"))
-	testJsonDecodePass(t, `["null","int","long"]`, Union("int", 3), []byte(`3`))
-	testJsonDecodePass(t, `["null","long","int"]`, Union("int", 3), []byte(`3`))
-	testJsonDecodePass(t, `["null","int","long"]`, Union("long", 333333333333333), []byte(`333333333333333`))
-	testJsonDecodePass(t, `["null","long","int"]`, Union("long", 333333333333333), []byte(`333333333333333`))
-	testJsonDecodePass(t, `["null","float","int","long"]`, Union("float", 6.77), []byte(`6.77`))
-	testJsonDecodePass(t, `["null","int","float","long"]`, Union("float", 6.77), []byte(`6.77`))
-	testJsonDecodePass(t, `["null","double","int","long"]`, Union("double", 6.77), []byte(`6.77`))
-	testJsonDecodePass(t, `["null","int","float","double","long"]`, Union("double", 6.77), []byte(`6.77`))
-	testJsonDecodePass(t, `["null",{"type":"array","items":"int"}]`, Union("array", []interface{}{1, 2}), []byte(`[1,2]`))
-	testJsonDecodePass(t, `["null",{"type":"map","values":"int"}]`, Union("map", map[string]interface{}{"k1": 13}), []byte(`{"k1":13}`))
-	testJsonDecodePass(t, `["null",{"name":"r1","type":"record","fields":[{"name":"field1","type":"string"},{"name":"field2","type":"string"}]}]`, Union("r1", map[string]interface{}{"field1": "value1", "field2": "value2"}), []byte(`{"field1": "value1", "field2": "value2"}`))
-	testJsonDecodePass(t, `["null","boolean"]`, Union("boolean", true), []byte(`true`))
-	testJsonDecodePass(t, `["null","boolean"]`, Union("boolean", false), []byte(`false`))
-	testJsonDecodePass(t, `["null",{"type":"enum","name":"e1","symbols":["alpha","bravo"]}]`, Union("e1", "bravo"), []byte(`"bravo"`))
-	testJsonDecodePass(t, `["null", "bytes"]`, Union("bytes", []byte("")), []byte("\"\""))
-	testJsonDecodePass(t, `["null", "bytes", "string"]`, Union("bytes", []byte("")), []byte("\"\""))
-	testJsonDecodePass(t, `["null", "string", "bytes"]`, Union("string", "value1"), []byte(`"value1"`))
-	testJsonDecodePass(t, `["null", {"type":"enum","name":"e1","symbols":["alpha","bravo"]}, "string"]`, Union("e1", "bravo"), []byte(`"bravo"`))
-	testJsonDecodePass(t, `["null", {"type":"fixed","name":"f1","size":4}]`, Union("f1", []byte(`abcd`)), []byte(`"abcd"`))
-	testJsonDecodePass(t, `"string"`, "abcd", []byte(`"abcd"`))
-	testJsonDecodePass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""}]}`, map[string]interface{}{"field1": "value1"}, []byte(`{"field1":"value1"}`))
-	testJsonDecodePass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""},{"name":"field2","type":"string"}]}`, map[string]interface{}{"field1": "", "field2": "deef"}, []byte(`{"field2": "deef"}`))
-	testJsonDecodePass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": Union("string", "value1")}, []byte(`{"field1":"value1"}`))
-	testJsonDecodePass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": nil}, []byte(`{"field1":null}`))
-	// union of null which has minimal syntax
-	testJsonDecodePass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": nil}, []byte(`{"next": null}`))
-	// record containing union of record (recursive record)
-	testJsonDecodePass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})}, []byte(`{"next":{"next":null}}`))
-	testJsonDecodePass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})})}, []byte(`{"next":{"next":{"next":null}}}`))
+type targs struct {
+	schema  string
+	datum   interface{}
+	encoded []byte
 }
 
-//testNativeToTextualJsonPass(t, `["null","int"]`, nil, []byte("null"))
-func TestUnionNativeToJson(t *testing.T) {
-	testNativeToTextualJsonPass(t, `["null","int"]`, nil, []byte("null"))
-	testNativeToTextualJsonPass(t, `["null","int","long"]`, Union("int", 3), []byte(`3`))
-	testNativeToTextualJsonPass(t, `["null","long","int"]`, Union("int", 3), []byte(`3`))
-	testNativeToTextualJsonPass(t, `["null","int","long"]`, Union("long", 333333333333333), []byte(`333333333333333`))
-	testNativeToTextualJsonPass(t, `["null","long","int"]`, Union("long", 333333333333333), []byte(`333333333333333`))
-	testNativeToTextualJsonPass(t, `["null","float","int","long"]`, Union("float", 6.77), []byte(`6.77`))
-	testNativeToTextualJsonPass(t, `["null","int","float","long"]`, Union("float", 6.77), []byte(`6.77`))
-	testNativeToTextualJsonPass(t, `["null","double","int","long"]`, Union("double", 6.77), []byte(`6.77`))
-	testNativeToTextualJsonPass(t, `["null","int","float","double","long"]`, Union("double", 6.77), []byte(`6.77`))
-	testNativeToTextualJsonPass(t, `["null",{"type":"array","items":"int"}]`, Union("array", []interface{}{1, 2}), []byte(`[1,2]`))
-	testNativeToTextualJsonPass(t, `["null",{"type":"map","values":"int"}]`, Union("map", map[string]interface{}{"k1": 13}), []byte(`{"k1":13}`))
-	testNativeToTextualJsonPass(t, `["null",{"name":"r1","type":"record","fields":[{"name":"field1","type":"string"},{"name":"field2","type":"string"}]}]`, Union("r1", map[string]interface{}{"field1": "value1", "field2": "value2"}), []byte(`{"field1":"value1","field2":"value2"}`))
-	testNativeToTextualJsonPass(t, `["null","boolean"]`, Union("boolean", true), []byte(`true`))
-	testNativeToTextualJsonPass(t, `["null","boolean"]`, Union("boolean", false), []byte(`false`))
-	testNativeToTextualJsonPass(t, `["null",{"type":"enum","name":"e1","symbols":["alpha","bravo"]}]`, Union("e1", "bravo"), []byte(`"bravo"`))
-	testNativeToTextualJsonPass(t, `["null", "bytes"]`, Union("bytes", []byte("")), []byte("\"\""))
-	testNativeToTextualJsonPass(t, `["null", "bytes", "string"]`, Union("bytes", []byte("")), []byte("\"\""))
-	testNativeToTextualJsonPass(t, `["null", "string", "bytes"]`, Union("string", "value1"), []byte(`"value1"`))
-	testNativeToTextualJsonPass(t, `["null", {"type":"enum","name":"e1","symbols":["alpha","bravo"]}, "string"]`, Union("e1", "bravo"), []byte(`"bravo"`))
-	testNativeToTextualJsonPass(t, `["null", {"type":"fixed","name":"f1","size":4}]`, Union("f1", []byte(`abcd`)), []byte(`"abcd"`))
-	testNativeToTextualJsonPass(t, `"string"`, "abcd", []byte(`"abcd"`))
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""}]}`, map[string]interface{}{"field1": "value1"}, []byte(`{"field1":"value1"}`))
+func TestUnionJson(t *testing.T) {
+	testData := []targs{
+		{`["null","int"]`, nil, []byte("null")},
+		{`["null","int","long"]`, Union("int", 3), []byte(`3`)},
+		{`["null","long","int"]`, Union("int", 3), []byte(`3`)},
+		{`["null","int","long"]`, Union("long", 333333333333333), []byte(`333333333333333`)},
+		{`["null","long","int"]`, Union("long", 333333333333333), []byte(`333333333333333`)},
+		{`["null","float","int","long"]`, Union("float", 6.77), []byte(`6.77`)},
+		{`["null","int","float","long"]`, Union("float", 6.77), []byte(`6.77`)},
+		{`["null","double","int","long"]`, Union("double", 6.77), []byte(`6.77`)},
+		{`["null","int","float","double","long"]`, Union("double", 6.77), []byte(`6.77`)},
+		{`["null",{"type":"array","items":"int"}]`, Union("array", []interface{}{1, 2}), []byte(`[1,2]`)},
+		{`["null",{"type":"map","values":"int"}]`, Union("map", map[string]interface{}{"k1": 13}), []byte(`{"k1":13}`)},
+		{`["null",{"name":"r1","type":"record","fields":[{"name":"field1","type":"string"},{"name":"field2","type":"string"}]}]`, Union("r1", map[string]interface{}{"field1": "value1", "field2": "value2"}), []byte(`{"field1": "value1", "field2": "value2"}`)},
+		{`["null","boolean"]`, Union("boolean", true), []byte(`true`)},
+		{`["null","boolean"]`, Union("boolean", false), []byte(`false`)},
+		{`["null",{"type":"enum","name":"e1","symbols":["alpha","bravo"]}]`, Union("e1", "bravo"), []byte(`"bravo"`)},
+		{`["null", "bytes"]`, Union("bytes", []byte("")), []byte("\"\"")},
+		{`["null", "bytes", "string"]`, Union("bytes", []byte("")), []byte("\"\"")},
+		{`["null", "string", "bytes"]`, Union("string", "value1"), []byte(`"value1"`)},
+		{`["null", {"type":"enum","name":"e1","symbols":["alpha","bravo"]}, "string"]`, Union("e1", "bravo"), []byte(`"bravo"`)},
+		{`["null", {"type":"fixed","name":"f1","size":4}]`, Union("f1", []byte(`abcd`)), []byte(`"abcd"`)},
+		{`"string"`, "abcd", []byte(`"abcd"`)},
+		{`{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""}]}`, map[string]interface{}{"field1": "value1"}, []byte(`{"field1":"value1"}`)},
+		{`{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": Union("string", "value1")}, []byte(`{"field1":"value1"}`)},
+		{`{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": nil}, []byte(`{"field1":null}`)},
+		{`{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": nil}, []byte(`{"next": null}`)},
+		{`{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})}, []byte(`{"next":{"next":null}}`)},
+		{`{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})})}, []byte(`{"next":{"next":{"next":null}}}`)},
+	}
+
+	for _, td := range testData {
+		testJsonDecodePass(t, td.schema, td.datum, td.encoded)
+		testNativeToTextualJsonPass(t, td.schema, td.datum, td.encoded)
+	}
+
+	//these two give different results depending on if its going into native or into a string
+	// when this goes to native it gets the "field2" because its given, but it also gets a "field1" because "field1" has a default value
+	// when this goes to a string it has a field from both "field1" and one for "field2"
+	testJsonDecodePass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""},{"name":"field2","type":"string"}]}`, map[string]interface{}{"field1": "", "field2": "deef"}, []byte(`{"field2": "deef"}`))
 	testNativeToTextualJsonPass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":"string","default":""},{"name":"field2","type":"string"}]}`, map[string]interface{}{"field1": "", "field2": "deef"}, []byte(`{"field1":"","field2":"deef"}`))
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": Union("string", "value1")}, []byte(`{"field1":"value1"}`))
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"kubeEvents","fields":[{"name":"field1","type":["string","null"],"default":""}]}`, map[string]interface{}{"field1": nil}, []byte(`{"field1":null}`))
-	// union of null which has minimal syntax
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": nil}, []byte(`{"next":null}`))
-	// record containing union of record (recursive record)
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})}, []byte(`{"next":{"next":null}}`))
-	testNativeToTextualJsonPass(t, `{"type":"record","name":"LongList","fields":[{"name":"next","type":["null","LongList"],"default":null}]}`, map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": Union("LongList", map[string]interface{}{"next": nil})})}, []byte(`{"next":{"next":{"next":null}}}`))
+
 }


### PR DESCRIPTION
per #247

I've added support for going from avro-encoded to standard json (no decoration of unions).  We already had the ability to go from standard json to avro-encoded data.  So this makes it support the full two-way flow of data.  The old code is still in there and unchanged.  To get the two-way functionality, use something like this to construct a codec:

```
func NewCodecForStandardJsonFull(schemaSpecification string) (*Codec, error) {
        return NewCodecFrom(schemaSpecification, &codecBuilder{
                buildCodecForTypeDescribedByMap,
                buildCodecForTypeDescribedByString,
                buildCodecForTypeDescribedBySliceTwoWayJson,
        })
}
```

I've also added a new function for anybody who might want the one-way, giving it a more obvious name:

```
func NewCodecForStandardJsonOneWay(schemaSpecification string) (*Codec, error) {
        return NewCodecForStandardJSON(schemaSpecification)
}
```

