### PR TITLE
UUID Logical Type Support

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -301,6 +301,15 @@ func newSymbolTable() map[string]*Codec {
 		},
 		// Start of compiled logical types using format typeName.logicalType where there is
 		// no dependence on schema.
+		"string.uuid": {
+			typeName:          &name{"string.uuid", nullNamespace},
+			schemaOriginal:    "string",
+			schemaCanonical:   "string",
+			binaryFromNative:  uuidFromNative(stringBinaryFromNative),
+			nativeFromBinary:  nativeFromUUID(stringNativeFromBinary),
+			textualFromNative: uuidFromNative(stringTextualFromNative),
+			nativeFromTextual: nativeFromUUID(stringNativeFromTextual),
+		},
 		"long.timestamp-millis": {
 			typeName:          &name{"long.timestamp-millis", nullNamespace},
 			schemaOriginal:    "long",

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/golang/snappy v0.0.1
+	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.5
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -10,6 +12,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -40,6 +40,13 @@ func TestLongLogicalTypeFallback(t *testing.T) {
 	testBinaryCodecPass(t, schema, 12345, []byte("\xf2\xc0\x01"))
 }
 
+func TestUUIDLogicalTypeEncode(t *testing.T) {
+	schema := `{"type": "string", "logicalType": "uuid"}`
+	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")
+	testBinaryEncodeFail(t, schema, "test", "cannot transform to binary uuid, expected valid uuid, received \"test\"")
+	testBinaryCodecPass(t, schema, "fec2c005-8c57-44c0-89bd-b39ab94afc7e", []byte("\x48\x66\x65\x63\x32\x63\x30\x30\x35\x2d\x38\x63\x35\x37\x2d\x34\x34\x63\x30\x2d\x38\x39\x62\x64\x2d\x62\x33\x39\x61\x62\x39\x34\x61\x66\x63\x37\x65"))
+}
+
 func TestTimeStampMillisLogicalTypeEncode(t *testing.T) {
 	schema := `{"type": "long", "logicalType": "timestamp-millis"}`
 	testBinaryDecodeFail(t, schema, []byte(""), "short buffer")


### PR DESCRIPTION
I've encountered a case where it would have been helpful to validate that a string in a field, `{"null", {"type": "string", "logicalType": "uuid"}], "default": null}`, was in fact a uuid.

To accomplish this, I've added two functions: `nativeFromUUID` and `uuidFromNative`. Both of these functions use [uuid.Parse](https://pkg.go.dev/github.com/google/uuid#Parse) to validate that an outgoing or incoming string is a UUID. I went this route rather than using a regex because I found [a gist that showed that google's uuid.Parse was much faster](https://gist.github.com/mattes/69a4ab7027b9e8ee952b5843e7ca6955). Hopefully, the project is not too opposed to introducing a new package, but I am happy to hear objections.

Please let me know if there's any changes I should make; I hope this is a useful contribution!