### PR TITLE
Fix incorrect calculation of canonical schema

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -120,6 +120,22 @@ func pcfObject(jsonMap map[string]interface{}, parentNamespace string, typeLooku
 			}
 		}
 
+		// This fixes a fairly subtle bug that can occur during schema canonicalization,
+		// which can randomly namespace a name that should not be, depending on the
+		// order of map traversal.
+		if theType, ok := jsonMap["type"]; ok {
+			// Check it's not a type that should be namespaced in canonical form, i.e.
+			// this should be map[string]interface{} and not "record".
+			if _, ook := theType.(string); !ook {
+				if valStr, oook := v.(string); oook {
+					// if we're an interface{} type which has an entry in typeLookup,
+					// remove it before we recurse into parsingCanonicalForm, as
+					// the wrong namespace will be applied.
+					delete(typeLookup, valStr)
+				}
+			}
+		}
+
 		pk, err := parsingCanonicalForm(k, parentNamespace, typeLookup)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
For some valid schemas, goavro will incorrectly compute the canonical form. This results in an incorrect Rabin fingerprint. Due to the random nature of map iteration in golang, the fingerprint for the exact same schema can change between consecutive runs, which should not happen.

The error occurs with namespaces, with two nested names that are the same. The outer name can get incorrectly namespaced if it is processed last, due to the name collision in the typeLookup map.

The fix is to remove the colliding name if the type is not one of the types that is supposed to be namespaced.