### PR TITLE
Fix byte slices using the same underlying array

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -39,7 +39,12 @@ func bytesNativeFromBinary(buf []byte) (interface{}, []byte, error) {
 	if size > int64(len(buf)) {
 		return nil, nil, fmt.Errorf("cannot decode binary bytes: %s", io.ErrShortBuffer)
 	}
-	return buf[:size], buf[size:], nil
+
+	// allocate new byte slice to avoid referencing the same underlying array
+	out := make([]byte, size)
+	copy(out, buf[:size])
+
+	return out, buf[size:], nil
 }
 
 func stringNativeFromBinary(buf []byte) (interface{}, []byte, error) {


### PR DESCRIPTION
This PR ensures that a new byte slice is created in `bytesNativeFromBinary` instead of reusing the same byte slice as the input buffer. It ensures that the created slice is referencing its own underlying array and makes any changes of that field safe (i.e. the changes won't affect the input buffer or any other fields in the decoded value).

Fixes https://github.com/linkedin/goavro/issues/269.