### PR TITLE
Make example errors fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ package main
 
 import (
     "fmt"
+    "log"
 
     "github.com/linkedin/goavro/v2"
 )
@@ -155,7 +156,7 @@ func main() {
           ]
         }`)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
 
     // NOTE: May omit fields when using default value
@@ -164,25 +165,25 @@ func main() {
     // Convert textual Avro data (in Avro JSON format) to native Go form
     native, _, err := codec.NativeFromTextual(textual)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
 
     // Convert native Go form to binary Avro data
     binary, err := codec.BinaryFromNative(nil, native)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
 
     // Convert binary Avro data back to native Go form
     native, _, err = codec.NativeFromBinary(binary)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
 
     // Convert native Go form to textual Avro data
     textual, err = codec.TextualFromNative(nil, native)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
 
     // NOTE: Textual encoding will show all fields, even those with values that
@@ -205,6 +206,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+    "log"
 	"strings"
 
 	"github.com/linkedin/goavro/v2"
@@ -234,7 +236,7 @@ func main() {
 		Schema: avroSchema,
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	err = writer.Append([]map[string]interface{}{
 		{
@@ -251,13 +253,13 @@ func main() {
 	// Reading OCF data
 	ocfReader, err := goavro.NewOCFReader(strings.NewReader(ocfFileContents.String()))
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	fmt.Println("Records in OCF File");
 	for ocfReader.Scan() {
 		record, err := ocfReader.Read()
 		if err != nil {
-			fmt.Println(err)
+			log.Fatal(err)
 		}
 		fmt.Println("record", record)
 	}
@@ -372,11 +374,11 @@ specified above.
 func ExampleUnion() {
     codec, err := goavro.NewCodec(`["null","string","int"]`)
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
     buf, err := codec.TextualFromNative(nil, goavro.Union("string", "some string"))
     if err != nil {
-        fmt.Println(err)
+        log.Fatal(err)
     }
     fmt.Println(string(buf))
     // Output: {"string":"some string"}

--- a/codec.go
+++ b/codec.go
@@ -93,7 +93,7 @@ type codecBuilder struct {
 //	      ]
 //	    }`)
 //	if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	}
 func NewCodec(schemaSpecification string) (*Codec, error) {
 	return NewCodecFrom(schemaSpecification, &codecBuilder{
@@ -133,7 +133,7 @@ func NewCodec(schemaSpecification string) (*Codec, error) {
 //	      ]
 //	    }`)
 //	if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	}
 //
 // The above will take json of this sort:
@@ -367,7 +367,7 @@ func newSymbolTable() map[string]*Codec {
 //	          ]
 //	        }`)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    // Convert native Go form to binary Avro data
@@ -383,7 +383,7 @@ func newSymbolTable() map[string]*Codec {
 //	        },
 //	    })
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    fmt.Printf("%#v", binary)
@@ -413,7 +413,7 @@ func (c *Codec) BinaryFromNative(buf []byte, datum interface{}) ([]byte, error) 
 //	          ]
 //	        }`)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    // Convert native Go form to binary Avro data
@@ -421,7 +421,7 @@ func (c *Codec) BinaryFromNative(buf []byte, datum interface{}) ([]byte, error) 
 //
 //	    native, _, err := codec.NativeFromBinary(binary)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    fmt.Printf("%v", native)
@@ -482,7 +482,7 @@ func (c *Codec) NativeFromSingle(buf []byte) (interface{}, []byte, error) {
 //	          ]
 //	        }`)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    // Convert native Go form to text Avro data
@@ -490,7 +490,7 @@ func (c *Codec) NativeFromSingle(buf []byte) (interface{}, []byte, error) {
 //
 //	    native, _, err := codec.NativeFromTextual(text)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    fmt.Printf("%v", native)
@@ -553,7 +553,7 @@ func (c *Codec) SingleFromNative(buf []byte, datum interface{}) ([]byte, error) 
 //	          ]
 //	        }`)
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    // Convert native Go form to text Avro data
@@ -569,7 +569,7 @@ func (c *Codec) SingleFromNative(buf []byte, datum interface{}) ([]byte, error) 
 //	        },
 //	    })
 //	    if err != nil {
-//	        fmt.Println(err)
+//	        log.Fatal(err)
 //	    }
 //
 //	    fmt.Printf("%s", text)

--- a/codec_test.go
+++ b/codec_test.go
@@ -12,6 +12,7 @@ package goavro
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 )
@@ -20,7 +21,7 @@ func ExampleCodec_CanonicalSchema() {
 	schema := `{"type":"map","values":{"type":"enum","name":"foo","symbols":["alpha","bravo"]}}`
 	codec, err := NewCodec(schema)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	} else {
 		fmt.Println(codec.CanonicalSchema())
 	}

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ Usage Example:
 	              ]
 	            }`)
 	        if err != nil {
-	            fmt.Println(err)
+	            log.Fatal(err)
 	        }
 
 	        // NOTE: May omit fields when using default value
@@ -38,25 +38,25 @@ Usage Example:
 	        // Convert textual Avro data (in Avro JSON format) to native Go form
 	        native, _, err := codec.NativeFromTextual(textual)
 	        if err != nil {
-	            fmt.Println(err)
+	            log.Fatal(err)
 	        }
 
 	        // Convert native Go form to binary Avro data
 	        binary, err := codec.BinaryFromNative(nil, native)
 	        if err != nil {
-	            fmt.Println(err)
+	            log.Fatal(err)
 	        }
 
 	        // Convert binary Avro data back to native Go form
 	        native, _, err = codec.NativeFromBinary(binary)
 	        if err != nil {
-	            fmt.Println(err)
+	            log.Fatal(err)
 	        }
 
 	        // Convert native Go form to textual Avro data
 	        textual, err = codec.TextualFromNative(nil, native)
 	        if err != nil {
-	            fmt.Println(err)
+	            log.Fatal(err)
 	        }
 
 	        // NOTE: Textual encoding will show all fields, even those with values that

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -11,6 +11,7 @@ package goavro
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"math/big"
 	"testing"
@@ -247,19 +248,19 @@ func ExampleUnion_logicalType() {
 	// * decimal          - big.Rat
 	codec, err := NewCodec(`["null", {"type": "long", "logicalType": "timestamp-millis"}]`)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Note the usage of type.logicalType i.e. `long.timestamp-millis` to denote the type in a union. This is due to the single string naming format
 	// used by goavro. Decimal can be both bytes.decimal or fixed.decimal
 	bytes, err := codec.BinaryFromNative(nil, map[string]interface{}{"long.timestamp-millis": time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	decoded, _, err := codec.NativeFromBinary(bytes)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	out := decoded.(map[string]interface{})
 	fmt.Printf("%#v\n", out["long.timestamp-millis"].(time.Time).String())

--- a/record_test.go
+++ b/record_test.go
@@ -12,6 +12,7 @@ package goavro
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"testing"
 )
 
@@ -456,7 +457,7 @@ func ExampleCodec_NativeFromTextual_roundTrip() {
 }
 `)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// NOTE: May omit fields when using default value
@@ -465,25 +466,25 @@ func ExampleCodec_NativeFromTextual_roundTrip() {
 	// Convert textual Avro data (in Avro JSON format) to native Go form
 	native, _, err := codec.NativeFromTextual(textual)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to binary Avro data
 	binary, err := codec.BinaryFromNative(nil, native)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert binary Avro data back to native Go form
 	native, _, err = codec.NativeFromBinary(binary)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to textual Avro data
 	textual, err = codec.TextualFromNative(nil, native)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// NOTE: Textual encoding will show all fields, even those with values that
@@ -503,7 +504,7 @@ func ExampleCodec_BinaryFromNative_avro() {
 }
 `)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to binary Avro data
@@ -519,7 +520,7 @@ func ExampleCodec_BinaryFromNative_avro() {
 		},
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	fmt.Printf("%#v", binary)
@@ -537,7 +538,7 @@ func ExampleCodec_NativeFromBinary_avro() {
 }
 `)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to binary Avro data
@@ -545,7 +546,7 @@ func ExampleCodec_NativeFromBinary_avro() {
 
 	native, _, err := codec.NativeFromBinary(binary)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	fmt.Printf("%v", native)
@@ -563,7 +564,7 @@ func ExampleCodec_NativeFromTextual_avro() {
 }
 `)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to text Avro data
@@ -571,7 +572,7 @@ func ExampleCodec_NativeFromTextual_avro() {
 
 	native, _, err := codec.NativeFromTextual(text)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	fmt.Printf("%v", native)
@@ -589,7 +590,7 @@ func ExampleCodec_TextualFromNative_avro() {
 }
 `)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	// Convert native Go form to text Avro data
@@ -605,7 +606,7 @@ func ExampleCodec_TextualFromNative_avro() {
 		},
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	fmt.Printf("%s", text)

--- a/schema_test.go
+++ b/schema_test.go
@@ -137,7 +137,7 @@ func TestSchemaFixedNameCanBeUsedLater(t *testing.T) {
 // 	schema := `{"type":"map","values":{"type":"enum","name":"foo","symbols":["alpha","bravo"]}}`
 // 	codec, err := NewCodec(schema)
 // 	if err != nil {
-// 		fmt.Println(err)
+// 		log.Fatal(err)
 // 	}
 // 	fmt.Println(codec.Schema())
 // 	// Output: {"type":"map","values":{"name":"foo","type":"enum","symbols":["alpha","bravo"]}}

--- a/union.go
+++ b/union.go
@@ -38,11 +38,11 @@ type codecInfo struct {
 //	func ExampleUnion() {
 //	   codec, err := goavro.NewCodec(`["null","string","int"]`)
 //	   if err != nil {
-//	       fmt.Println(err)
+//	       log.Fatal(err)
 //	   }
 //	   buf, err := codec.TextualFromNative(nil, goavro.Union("string", "some string"))
 //	   if err != nil {
-//	       fmt.Println(err)
+//	       log.Fatal(err)
 //	   }
 //	   fmt.Println(string(buf))
 //	   // Output: {"string":"some string"}

--- a/union_test.go
+++ b/union_test.go
@@ -12,6 +12,7 @@ package goavro
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"math"
 	"strconv"
 	"testing"
@@ -162,11 +163,11 @@ func TestUnionText(t *testing.T) {
 func ExampleCodec_TextualFromNative_union() {
 	codec, err := NewCodec(`["null","string","int"]`)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	buf, err := codec.TextualFromNative(nil, Union("string", "some string"))
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	fmt.Println(string(buf))
 	// Output: {"string":"some string"}
@@ -180,12 +181,12 @@ func ExampleCodec_TextualFromNative_union_json() {
 	// parse the string accordingly.
 	codec, err := NewCodec(`["null","double","string"]`)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	native, _, err := codec.NativeFromTextual([]byte(`{"string":"NaN"}`))
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	value := math.NaN()
@@ -211,7 +212,7 @@ func ExampleCodec_TextualFromNative_union_json() {
 					var err error
 					value, err = strconv.ParseFloat(s, 64)
 					if err != nil {
-						fmt.Println(err)
+						log.Fatal(err)
 					}
 				}
 			}
@@ -235,11 +236,11 @@ func ExampleCodec_TextualFromNative() {
 		buildCodecForTypeDescribedBySlice,
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	buf, err := codec.TextualFromNative(nil, "some string 22")
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	fmt.Println(string(buf))
 	// Output: "some string 22"
@@ -253,11 +254,11 @@ func ExampleCodec_TextualFromNative_json() {
 		buildCodecForTypeDescribedBySliceOneWayJSON,
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	buf, err := codec.TextualFromNative(nil, Union("string", "some string"))
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	fmt.Println(string(buf))
 	// Output: {"string":"some string"}
@@ -270,12 +271,12 @@ func ExampleCodec_NativeFromTextual_json() {
 		buildCodecForTypeDescribedBySliceOneWayJSON,
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	// send in a legit json string
 	t, _, err := codec.NativeFromTextual([]byte("\"some string one\""))
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 	// see it parse into a map like the avro encoder does
 	o, ok := t.(map[string]interface{})


### PR DESCRIPTION
Execution continues following `fmt.Println(err)`. Since the go standard library uses a combination of `panic` and `log.Fatalf` in its examples, it's probably a good idea to use the same pattern here.

If I hadn't tripped over this issue while working on #271, I could totally see myself copying one of these examples and glossing over the non-standard, non-terminating error handling code and letting it wind up in my application.