### PR TITLE
Update import to v2 in doc example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ Usage Example:
 	    import (
 	        "fmt"
 
-	        "github.com/linkedin/goavro"
+	        "github.com/linkedin/goavro/v2"
 	    )
 
 	    func main() {


### PR DESCRIPTION
The doc example (which shows up [here](https://pkg.go.dev/github.com/linkedin/goavro/v2)) still uses the old-style import without `/v2`. Updating it accordingly.