### PR TITLE
ocfwriter: allow writing blocks

### DIFF
--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -215,14 +215,18 @@ func (ocfw *OCFWriter) appendDataIntoBlock(data []interface{}) error {
 
 	}
 
+	return ocfw.AppendBlock(block, len(data))
+}
+
+func (ocfw *OCFWriter) AppendBlock(block []byte, count int) error {
 	// create file data block
 	buf := make([]byte, 0, len(block)+ocfBlockConst) // pre-allocate block bytes
-	buf, _ = longBinaryFromNative(buf, len(data))    // block count (number of data items)
+	buf, _ = longBinaryFromNative(buf, count)        // block count (number of data items)
 	buf, _ = longBinaryFromNative(buf, len(block))   // block size (number of bytes in block)
 	buf = append(buf, block...)                      // serialized objects
 	buf = append(buf, ocfw.header.syncMarker[:]...)  // sync marker
 
-	_, err = ocfw.iow.Write(buf)
+	_, err := ocfw.iow.Write(buf)
 	return err
 }
 


### PR DESCRIPTION
Exports an `AppendBlock` function which `Append` uses. Our use case is that we have a go routine that sends batches of `[]map[string]interface{}` over a channel and a reader which then `Append`s it to a block. This forces us to compress and append smaller blocks for each batch we receive. This code change allows us to build up the block over time, by converting (using `codec`) on the fly, appending to a block, and compressing at the same time. We can then compress all data into a single data block.

In the worst case, calling `Append` many times was more than doubling, and almost tripling, the actual file sizes compared to calling Append a few times per file.