### PR TITLE
feat: expose codec full name

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -604,6 +604,14 @@ func (c *Codec) SchemaCRC64Avro() int64 {
 	return int64(c.Rabin)
 }
 
+// Name returns the name of the Avro schema used to create the Codec.
+func (c *Codec) Name() (string, error) {
+	if c.typeName == nil {
+		return "", fmt.Errorf("codec has no name")
+	}
+	return c.typeName.String(), nil
+}
+
 // convert a schema data structure to a codec, prefixing with specified
 // namespace
 func buildCodec(st map[string]*Codec, enclosingNamespace string, schema interface{}, cb *codecBuilder) (*Codec, error) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -27,6 +27,22 @@ func ExampleCodec_CanonicalSchema() {
 	// Output: {"type":"map","values":{"name":"foo","type":"enum","symbols":["alpha","bravo"]}}
 }
 
+func ExampleCodec_Name() {
+	schema := `{"type":"map","values":{"type":"enum","name":"foo","symbols":["alpha","bravo"]}}`
+	codec, err := NewCodec(schema)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		name, errName := codec.Name()
+		if errName != nil {
+			fmt.Println(errName)
+		} else {
+			fmt.Println(name)
+		}
+	}
+	// Output: map
+}
+
 func TestCodecRabin(t *testing.T) {
 	cases := []struct {
 		Schema string


### PR DESCRIPTION
add codec full name to allow use of TopicRecordNameStrategy, retrieving name from codec