### PR TITLE
Support unambiguous JSON (from/to)

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -213,19 +213,19 @@ func NewCodecForStandardJSONFull(schemaSpecification string) (*Codec, error) {
 // optional types:
 //
 //	type Person struct {
-//			Name *string `json:"name,omitempty"`
+//	   Name *string `json:"name,omitempty"`
 //	}
 //
 // or using json.Marshal with structs containing a union:
 //
 //	type Message struct {
-//			Direction DirectionUnion `json:DirectionUnion"
+//	   Direction DirectionUnion `json:DirectionUnion"
 //	}
 //
 // type DirectionUnion struct { // only one of the fields can be non-nil
 //
-//			Request *string `json:"request,omitempty"`
-//			Response *string `json:"response,omitempty"`
+//	   Request *string `json:"request,omitempty"`
+//	   Response *string `json:"response,omitempty"`
 //	}
 func NewCodecForUnambiguousJSON(schemaSpecification string) (*Codec, error) {
 	return NewCodecFrom(schemaSpecification, &codecBuilder{

--- a/codec.go
+++ b/codec.go
@@ -198,6 +198,26 @@ func NewCodecForStandardJSONFull(schemaSpecification string) (*Codec, error) {
 	})
 }
 
+// NewCodecForUnambiguousJSON provides full serialization/deserialization
+// for json that meets the expectations of regular internet json, viewed as
+// something distinct from avro-json which has special handling for union
+// types.  For details see the above comments.
+//
+// With this `codec` you can expect to see a json string like this:
+//
+// "Follow your bliss."
+//
+// to deserialize into the same json structure
+//
+// "Follow your bliss."
+func NewCodecForUnambiguousJSON(schemaSpecification string) (*Codec, error) {
+	return NewCodecFrom(schemaSpecification, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+}
+
 func NewCodecFrom(schemaSpecification string, cb *codecBuilder) (*Codec, error) {
 	var schema interface{}
 

--- a/union_test.go
+++ b/union_test.go
@@ -263,6 +263,214 @@ func ExampleCodec_TextualFromNative_json() {
 	// Output: {"string":"some string"}
 }
 
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_TextualFromNative_unambiguous_primitive() {
+	codec, err := NewCodecFrom(`["null","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	buf, err := codec.TextualFromNative(nil, Union("string", "some string"))
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(buf))
+	// Output: "some string"
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_NativeFromTextual_unambiguous_primitive() {
+	codec, err := NewCodecFrom(`["null","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// send in a legit json string
+	t, _, err := codec.NativeFromTextual([]byte("\"some string\""))
+	if err != nil {
+		fmt.Println(err)
+	}
+	// see it parse directly into string
+	o, ok := t.(string)
+	if !ok {
+		fmt.Printf("its a %T not a string", t)
+	}
+	// pull out the string to show its all good
+	fmt.Println(o)
+	// Output: some string
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_TextualFromNative_unambiguous_record() {
+	codec, err := NewCodecFrom(`["null",{"type": "record", "name": "Person", "fields": [{"name": "name", "type": "string"}]}]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	buf, err := codec.TextualFromNative(nil, Union("Person", map[string]interface{}{"name": "John Doe"}))
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(buf))
+	// Output: {"name":"John Doe"}
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_NativeFromTextual_unambiguous_record() {
+	codec, err := NewCodecFrom(`["null",{"type": "record", "name": "Person", "fields": [{"name": "name", "type": "string"}]}]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// send in a legit json string
+	t, _, err := codec.NativeFromTextual([]byte("{\"name\": \"John Doe\"}"))
+	if err != nil {
+		fmt.Println(err)
+	}
+	// see it parse directly into string
+	o, ok := t.(map[string]interface{})
+	if !ok {
+		fmt.Printf("its a %T not a string", t)
+	}
+	// pull out the string to show its all good
+	fmt.Println(o)
+	// Output: map[name:John Doe]
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_TextualFromNative_unambiguous_nil() {
+	codec, err := NewCodecFrom(`["null","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	buf, err := codec.TextualFromNative(nil, Union("null", nil))
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(buf))
+	// Output: null
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_NativeFromTextual_unambiguous_nil() {
+	codec, err := NewCodecFrom(`["null","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// send in a legit json string
+	t, _, err := codec.NativeFromTextual([]byte("null"))
+	if err != nil {
+		fmt.Println(err)
+	}
+	// pull out the string to show its all good
+	fmt.Println(t)
+	// Output: <nil>
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_TextualFromNative_ambiguous_primitive() {
+	codec, err := NewCodecFrom(`["int","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	buf, err := codec.TextualFromNative(nil, Union("string", "some string"))
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(buf))
+	// Output: {"string":"some string"}
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_NativeFromTextual_ambiguous_primitive() {
+	codec, err := NewCodecFrom(`["int","string"]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// send in a legit json string
+	t, _, err := codec.NativeFromTextual([]byte("{\"string\": \"some string\"}"))
+	// see it parse into a map like the avro encoder does
+	o, ok := t.(map[string]interface{})
+	if !ok {
+		fmt.Printf("its a %T not a map[string]interface{}", t)
+	}
+	// pull out the string to show its all good
+	v := o["string"]
+	fmt.Println(v)
+	// Output: some string
+}
+
+func ExampleCodec_TextualFromNative_ambiguous_record() {
+	codec, err := NewCodecFrom(`["int",{"type": "record", "name": "Person", "fields": [{"name": "name", "type": "string"}]}]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	buf, err := codec.TextualFromNative(nil, Union("Person", map[string]interface{}{"name": "John Doe"}))
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(buf))
+	// Output: {"Person":{"name":"John Doe"}}
+}
+
+// Use the unambiguous JSON codec instead for nullable types
+func ExampleCodec_NativeFromTextual_ambiguous_record() {
+	codec, err := NewCodecFrom(`["int",{"type": "record", "name": "Person", "fields": [{"name": "name", "type": "string"}]}]`, &codecBuilder{
+		buildCodecForTypeDescribedByMap,
+		buildCodecForTypeDescribedByString,
+		buildCodecForTypeDescribedBySliceUnambiguousJSON,
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// send in a legit json string
+	t, _, err := codec.NativeFromTextual([]byte("{\"Person\": {\"name\": \"John Doe\"}}"))
+	if err != nil {
+		fmt.Println(err)
+	}
+	// see it parse into a map like the avro encoder does
+	o, ok := t.(map[string]interface{})
+	if !ok {
+		fmt.Printf("its a %T not a map[string]interface{}", t)
+	}
+	// pull out the Person to show its all good
+	v := o["Person"]
+	fmt.Println(v)
+	// Output: map[name:John Doe]
+}
+
 func ExampleCodec_NativeFromTextual_json() {
 	codec, err := NewCodecFrom(`["null","string","int"]`, &codecBuilder{
 		buildCodecForTypeDescribedByMap,


### PR DESCRIPTION
`NewCodecForUnambiguousJSON provides` full serialization/deserialization for json that is unambiguous in terms of what the field will contain. This means that avro Union types containing only a single concrete type e.g. `["null", "string"]` no longer have to specify their type. Unlike `NewCodecForStandardJSONFull`, ambiguous types `["int", "string"]` do still
need to specify their type as map. See the following examples:
```
["null", "string"] => "some string" || null
["int", "string"] => {"int": 1} || {"string": "some string"}
["null", "int", "string"] => null || {"int": 1} || {"string": "some string"}
```

this is especially useful when using `json.Marshal`, `json.Unmarshal` with structs containing
optional types:

```go
type Person struct {
   Name *string `json:"name,omitempty"`
}
```

or using `json.Marshal`,`json.Unmarshal` with structs containing a union:
```
type Message struct {
   Direction DirectionUnion `json:DirectionUnion"
}

type DirectionUnion struct { // only one of the fields can be non-nil
   Request *string `json:"request,omitempty"`
   Response *string `json:"response,omitempty"`
}
```

I have added example tests for (un)ambiguous nil, primitive and records native-to-textual and vice-versa


	