### PR TITLE
Ability to specify sync marker to an OCFWriter

### DIFF
--- a/ocf.go
+++ b/ocf.go
@@ -100,13 +100,16 @@ func newOCFHeader(config OCFConfig) (*ocfHeader, error) {
 	}
 
 	header.metadata = config.MetaData
+	header.syncMarker = config.SyncMarker
 
-	//
-	// The 16-byte, randomly-generated sync marker for this file.
-	//
-	_, err = rand.Read(header.syncMarker[:])
-	if err != nil {
-		return nil, err
+	if header.syncMarker == [16]byte{} {
+		//
+		// The 16-byte, randomly-generated sync marker for this file.
+		//
+		_, err = rand.Read(header.syncMarker[:])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return header, nil

--- a/ocf_test.go
+++ b/ocf_test.go
@@ -94,3 +94,24 @@ func TestOCFWriterCompressionSnappy(t *testing.T) {
 func TestOCFWriterWithApplicationMetaData(t *testing.T) {
 	testOCFRoundTripWithHeaders(t, CompressionNullLabel, map[string][]byte{"foo": []byte("BOING"), "goo": []byte("zoo")})
 }
+
+func TestOCFWriterWithSyncBlock(t *testing.T) {
+	buf := &bytes.Buffer{}
+	config := OCFConfig{
+		W:          buf,
+		Schema:     `{"type":"long"}`,
+		SyncMarker: [16]byte{9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6},
+	}
+	_, err := NewOCFWriter(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewOCFReader(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.header.syncMarker != config.SyncMarker {
+		t.Errorf("GOT: %v; WANT: %v", r.header.syncMarker, config.SyncMarker)
+	}
+}

--- a/ocf_writer.go
+++ b/ocf_writer.go
@@ -55,6 +55,10 @@ type OCFConfig struct {
 	// the OCF file.  When appending to an existing OCF, this field
 	// is ignored.
 	MetaData map[string][]byte
+
+	// SyncMarker specifies the sync block (optional). When not set, it will be
+	// randomly generated
+	SyncMarker [16]byte
 }
 
 // OCFWriter is used to create a new or append to an existing Avro Object


### PR DESCRIPTION
In some cases, we want to generate avro files with our own sync marker.
This PR allows one to supply one via the optional `SyncMarker` field of `OCFConfig`.