### PR TITLE
Add SkipAdditionalFields codec option

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -49,6 +49,11 @@ type CodecOption struct {
 	// When true, the string literal "null" in textual Avro data will be coerced to Go's nil.
 	// Primarily used to handle edge cases where some Avro implementations allow string representations of null.
 	EnableStringNull bool
+
+	// SkipAdditionalFields controls handling of additional fields during decoding.
+	// When true, any additional input fields not defined in the schema will be skipped during decoding.
+	// When false (default), any additional input fields not defined in the schema will result in an error.
+	SkipAdditionalFields bool
 }
 
 // Codec supports decoding binary and text Avro data to Go native data types,

--- a/record.go
+++ b/record.go
@@ -200,7 +200,7 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 		// NOTE: Setting `defaultCodec == nil` instructs genericMapTextDecoder
 		// to return an error when a field name is not found in the
 		// codecFromFieldName map.
-		mapValues, buf, err = genericMapTextDecoder(buf, nil, codecFromFieldName)
+		mapValues, buf, err = genericMapTextDecoder(buf, nil, codecFromFieldName, cb.option.SkipAdditionalFields)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot decode textual record %q: %s", c.typeName, err)
 		}

--- a/union.go
+++ b/union.go
@@ -24,6 +24,7 @@ type codecInfo struct {
 	codecFromIndex []*Codec
 	codecFromName  map[string]*Codec
 	indexFromName  map[string]int
+	option         *CodecOption
 }
 
 // Union wraps a datum value in a map for encoding as a Union, as required by
@@ -83,6 +84,7 @@ func makeCodecInfo(st map[string]*Codec, enclosingNamespace string, schemaArray 
 		codecFromIndex: codecFromIndex,
 		codecFromName:  codecFromName,
 		indexFromName:  indexFromName,
+		option:         cb.option,
 	}, nil
 
 }
@@ -151,7 +153,7 @@ func unionNativeFromTextual(cr *codecInfo) func(buf []byte) (interface{}, []byte
 
 		var datum interface{}
 		var err error
-		datum, buf, err = genericMapTextDecoder(buf, nil, cr.codecFromName)
+		datum, buf, err = genericMapTextDecoder(buf, nil, cr.codecFromName, cr.option.SkipAdditionalFields)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot decode textual union: %s", err)
 		}


### PR DESCRIPTION
Introduces a new `CodecOption.SkipAdditionalFields` that allows decoding textual Avro data with additional fields not defined in the schema. When enabled, unknown fields are skipped instead of causing errors.

This is useful for schema evolution scenarios where newer data formats may include fields that older schemas don't define. The option defaults to `false` to maintain backward compatibility.

Changes:
    - Add `SkipAdditionalFields` field to `CodecOption`
    - Update `genericMapTextDecoder` to skip unknown fields when enabled
    - Add `advanceToNextValue` helper to skip JSON values

Related to #294