### PR TITLE
Fix fixed type slices using same underlying array

### DIFF
--- a/fixed.go
+++ b/fixed.go
@@ -30,7 +30,11 @@ func makeFixedCodec(st map[string]*Codec, enclosingNamespace string, schemaMap m
 		if buflen := uint(len(buf)); size > buflen {
 			return nil, nil, fmt.Errorf("cannot decode binary fixed %q: schema size exceeds remaining buffer size: %d > %d (short buffer)", c.typeName, size, buflen)
 		}
-		return buf[:size], buf[size:], nil
+		// Make a copy to avoid the returned slice sharing the same underlying
+		// array as the input buffer and other decoded values.
+		result := make([]byte, size)
+		copy(result, buf[:size])
+		return result, buf[size:], nil
 	}
 
 	c.binaryFromNative = func(buf []byte, datum interface{}) ([]byte, error) {


### PR DESCRIPTION
## Summary

Fix a bug where decoded fixed type values share the same underlying array as the input buffer and other decoded values, causing unexpected behavior when appending to these slices.

## Problem

This is the same issue as #269 but for the `fixed` type. PR #270 fixes the `bytes` type but does not address the `fixed` type which has the identical problem.

When decoding binary fixed types in `makeFixedCodec`, the `nativeFromBinary` function returns `buf[:size]` directly - a subslice of the input buffer. This means:

1. All decoded fixed values share the same underlying array as the input
2. Appending to a decoded slice can overwrite data in other decoded slices
3. Modifications can corrupt the original input buffer

## Solution

Allocate a new slice and copy the data instead of returning a subslice:

```go
result := make([]byte, size)
copy(result, buf[:size])
return result, buf[size:], nil
```

This ensures each decoded fixed value has its own independent backing array.

## Testing

Added `TestFixedSlicesUseIndependentBackingArrays` which:
1. Decodes a record with two fixed fields from a binary buffer
2. Verifies the initial decoded values are correct
3. Appends to one field and verifies the other field and original buffer are unchanged

All existing tests continue to pass.

## Related

- Issue #269: Decoded bytes use the same underlying array
- PR #270: Fix byte slices using the same underlying array (bytes type only)